### PR TITLE
Allow whitelisted non-write users to trigger Claude Code

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,13 +10,11 @@ on:
   pull_request_review:
     types: [submitted]
 
-env:
-  ALLOWED_USERS: '["MoLow","Saturn7X"]'
-
+# Keep in sync with `allowed_non_write_users` below.
 jobs:
   claude:
     if: |
-      contains(fromJSON(env.ALLOWED_USERS), github.actor) &&
+      contains(fromJSON('["MoLow","Saturn7X"]'), github.actor) &&
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -47,7 +45,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.CLAUDE_BOT_PAT }}
-          allowed_non_write_users: ${{ join(fromJSON(env.ALLOWED_USERS), ',') }}
+          # Keep in sync with the `if` condition above.
+          allowed_non_write_users: "MoLow,Saturn7X"
           claude_args: '--allowedTools "Bash(npm *)" "Bash(node *)" "Bash(gh pr:*)" "Bash(gh issue *)" "Bash(git *)"'
           prompt: "${{ github.event_name == 'issues' && github.event.action == 'opened' && format('Read issue #{0} and create a PR that fixes it. The issue title is: {1}', github.event.issue.number, github.event.issue.title) || '' }}"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,11 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
-# Keep in sync with `allowed_non_write_users` below.
 jobs:
   claude:
     if: |
-      contains(fromJSON('["MoLow","Saturn7X"]'), github.actor) &&
+      contains(fromJSON(vars.ALLOWED_USERS), github.actor) &&
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -45,8 +44,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.CLAUDE_BOT_PAT }}
-          # Keep in sync with the `if` condition above.
-          allowed_non_write_users: "MoLow,Saturn7X"
+          allowed_non_write_users: ${{ join(fromJSON(vars.ALLOWED_USERS), ',') }}
           claude_args: '--allowedTools "Bash(npm *)" "Bash(node *)" "Bash(gh pr:*)" "Bash(gh issue *)" "Bash(git *)"'
           prompt: "${{ github.event_name == 'issues' && github.event.action == 'opened' && format('Read issue #{0} and create a PR that fixes it. The issue title is: {1}', github.event.issue.number, github.event.issue.title) || '' }}"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,8 +10,20 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  ALLOWED_USERS: '["MoLow","Saturn7X"]'
+
 jobs:
   claude:
+    if: |
+      contains(fromJSON(env.ALLOWED_USERS), github.actor) &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && github.event.action == 'opened') ||
+        (github.event_name == 'issues' && github.event.action == 'assigned' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -35,7 +47,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.CLAUDE_BOT_PAT }}
-          allowed_non_write_users: "MoLow,Saturn7X"
+          allowed_non_write_users: ${{ join(fromJSON(env.ALLOWED_USERS), ',') }}
           claude_args: '--allowedTools "Bash(npm *)" "Bash(node *)" "Bash(gh pr:*)" "Bash(gh issue *)" "Bash(git *)"'
           prompt: "${{ github.event_name == 'issues' && github.event.action == 'opened' && format('Read issue #{0} and create a PR that fixes it. The issue title is: {1}', github.event.issue.number, github.event.issue.title) || '' }}"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,15 +12,6 @@ on:
 
 jobs:
   claude:
-    if: |
-      (github.actor == 'MoLow' || github.actor == 'Saturn7X') &&
-      (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && github.event.action == 'opened') ||
-        (github.event_name == 'issues' && github.event.action == 'assigned' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -43,6 +34,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.CLAUDE_BOT_PAT }}
+          allowed_non_write_users: "MoLow,Saturn7X"
           claude_args: '--allowedTools "Bash(npm *)" "Bash(node *)" "Bash(gh pr:*)" "Bash(gh issue *)" "Bash(git *)"'
           prompt: "${{ github.event_name == 'issues' && github.event.action == 'opened' && format('Read issue #{0} and create a PR that fixes it. The issue title is: {1}', github.event.issue.number, github.event.issue.title) || '' }}"
 


### PR DESCRIPTION
## Summary
- Pass a PAT via `github_token` and set `allowed_non_write_users: "MoLow,Saturn7X"` so collaborators without repo write access can trigger the workflow
- Drop the job-level `if` gate — `allowed_non_write_users` is now the single actor whitelist (the action rejects anyone else)

## Setup required before this works
Create a fine-grained PAT scoped to this repo with Contents / Pull requests / Issues (and Workflows if Claude may edit workflow files) set to read+write, then add it as a repo secret named `CLAUDE_BOT_PAT`.

Fixes the "User does not have write access on this repository" failure seen on runs triggered by Saturn7X.

## Test plan
- [ ] Create the `CLAUDE_BOT_PAT` repo secret
- [ ] Trigger the workflow as Saturn7X (open an issue or comment `@claude`) and confirm it runs without the write-access error
- [ ] Trigger as MoLow and confirm it still works
- [ ] Trigger as a non-whitelisted user and confirm the action rejects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)