### PR TITLE
fix: address PageSpeed audit issues

### DIFF
--- a/website/.browserslistrc
+++ b/website/.browserslistrc
@@ -1,0 +1,4 @@
+last 2 Chrome versions
+last 2 Firefox versions
+last 2 Safari versions
+last 2 Edge versions

--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -61,7 +61,7 @@ export default async function RecipeGrid({
           }}
         >
           <Image
-            src="/savta.jpg"
+            src="/savta.webp"
             alt="Savta"
             fill
             className="object-cover object-top"

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -1,0 +1,41 @@
+import { getAllRecipes } from '@/lib/recipes';
+import type { MetadataRoute } from 'next';
+
+const BASE_URL = 'https://recipes.atlow.co.il';
+const LOCALES = ['en', 'he'] as const;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const recipes = getAllRecipes();
+
+  const staticRoutes: MetadataRoute.Sitemap = LOCALES.flatMap((locale) => [
+    {
+      url: `${BASE_URL}/${locale}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 1.0,
+    },
+    {
+      url: `${BASE_URL}/${locale}/search`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.5,
+    },
+    {
+      url: `${BASE_URL}/${locale}/about`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.3,
+    },
+  ]);
+
+  const recipeRoutes: MetadataRoute.Sitemap = LOCALES.flatMap((locale) =>
+    recipes.map((recipe) => ({
+      url: `${BASE_URL}/${locale}/recipe/${recipe.slug}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    }))
+  );
+
+  return [...staticRoutes, ...recipeRoutes];
+}

--- a/website/components/RecipeCard.tsx
+++ b/website/components/RecipeCard.tsx
@@ -46,9 +46,9 @@ export default function RecipeCard({
           WebkitBackdropFilter: "blur(16px) saturate(1.2)",
         }}
       >
-        <h3 className="font-semibold text-sm sm:text-base text-[var(--color-ink)] truncate leading-tight">
+        <h2 className="font-semibold text-sm sm:text-base text-[var(--color-ink)] truncate leading-tight">
           {title[locale]}
-        </h3>
+        </h2>
         {tags && tags.length > 0 && (
           <p className="text-[10px] sm:text-xs text-[var(--color-ink-tertiary)] truncate mt-0.5">
             {tags.slice(0, 3).map((t) => t[locale]).join(" \u00b7 ")}

--- a/website/components/SearchResults.tsx
+++ b/website/components/SearchResults.tsx
@@ -91,9 +91,9 @@ export default function SearchResults({ recipes, locale }: SearchResultsProps) {
                   WebkitBackdropFilter: "blur(16px) saturate(1.2)",
                 }}
               >
-                <h3 className="font-semibold text-sm sm:text-base text-[var(--color-ink)] truncate leading-tight">
+                <h2 className="font-semibold text-sm sm:text-base text-[var(--color-ink)] truncate leading-tight">
                   {locale === "he" ? r.titleHe : r.titleEn}
-                </h3>
+                </h2>
                 <p className="text-[10px] sm:text-xs text-[var(--color-ink-tertiary)] truncate mt-0.5">
                   {(locale === "he" ? r.tagsHe : r.tagsEn).slice(0, 3).join(" \u00b7 ")}
                 </p>

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://recipes.atlow.co.il/sitemap.xml

--- a/website/scripts/optimize-images.ts
+++ b/website/scripts/optimize-images.ts
@@ -19,6 +19,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = resolve(__dirname, "../..");
 const ILLUSTRATIONS_DIR = resolve(ROOT_DIR, "data/illustrations");
 const SCANS_DIR = resolve(ROOT_DIR, "data/scans");
+const PUBLIC_DIR = resolve(__dirname, "../public");
 
 const force = process.argv.includes("--force");
 
@@ -110,6 +111,26 @@ async function main() {
           { suffix: "-1200w", width: 1200, quality: 85 },
         ],
         label: `scans/${file}`,
+      });
+    }
+  }
+
+
+  // Static public assets
+  const staticAssets = [
+    { file: 'savta.jpg', variants: [{ suffix: '', width: 300, quality: 85 }] },
+  ];
+
+  for (const { file, variants } of staticAssets) {
+    const inputPath = resolve(PUBLIC_DIR, file);
+    if (existsSync(inputPath)) {
+      const name = basename(file, extname(file));
+      work.push({
+        input: inputPath,
+        outputDir: PUBLIC_DIR,
+        nameBase: name,
+        variants: variants.map((v) => ({ ...v, format: 'webp' as const })),
+        label: `public/${file}`,
       });
     }
   }


### PR DESCRIPTION
Fixes #48

## Summary
- **robots.txt**: Created `website/public/robots.txt` with `Allow: /` and `Sitemap:` directive — previously missing (404), flagged as invalid by PageSpeed
- **Sitemap**: Added `website/app/sitemap.ts` generating `sitemap.xml` at build time for all locale + recipe routes
- **Heading hierarchy**: Changed `<h3>` → `<h2>` in `RecipeCard` and `SearchResults` — both pages had an H1→H3 jump, skipping H2
- **Image delivery**: `savta.jpg` (389 KB JPEG) is now pre-converted to WebP at 300px during prebuild; the grid page serves `savta.webp` (OG metadata keeps JPEG for social media compatibility)
- **Legacy JavaScript**: Added `website/.browserslistrc` targeting last 2 versions of modern browsers, reducing polyfill output from Next.js

## Test plan
- [ ] `npm run build` in `website/` completes without errors (prebuild generates `public/savta.webp`)
- [ ] `/sitemap.xml` is present in the build output
- [ ] `/robots.txt` is served correctly
- [ ] Recipe grid page shows Savta portrait (verify network tab: `savta.webp` loaded, not `savta.jpg`)
- [ ] Heading structure: recipe cards use `<h2>` (inspect element), no H1→H3 jumps
- [ ] Re-run PageSpeed on mobile and desktop — check resolved items

🤖 Generated with [Claude Code](https://claude.com/claude-code)