### PR TITLE
feat: add RFC 8288 Link headers for agent discovery

### DIFF
--- a/infra/cloudformation.yaml
+++ b/infra/cloudformation.yaml
@@ -92,6 +92,19 @@ Resources:
           return request;
         }
 
+  # -- CloudFront Response Headers Policy (agent discovery) --
+  ResponseHeadersPolicy:
+    Type: AWS::CloudFront::ResponseHeadersPolicy
+    Properties:
+      ResponseHeadersPolicyConfig:
+        Name: !Sub "${AWS::StackName}-agent-ready"
+        Comment: RFC 8288 Link header for agent discovery (RFC 9727)
+        CustomHeadersConfig:
+          Items:
+            - Header: Link
+              Value: '</.well-known/api-catalog>; rel="api-catalog"'
+              Override: false
+
   # ── CloudFront Distribution ──
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
@@ -111,6 +124,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized
           Compress: true
+          ResponseHeadersPolicyId: !Ref ResponseHeadersPolicy
           FunctionAssociations:
             - EventType: viewer-request
               FunctionARN: !GetAtt UrlRewriteFunction.FunctionARN

--- a/website/public/.well-known/api-catalog
+++ b/website/public/.well-known/api-catalog
@@ -1,0 +1,19 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://recipes.atlow.co.il/",
+      "service-doc": [
+        {
+          "href": "https://recipes.atlow.co.il/en/about",
+          "type": "text/html"
+        }
+      ],
+      "describedby": [
+        {
+          "href": "https://recipes.atlow.co.il/sitemap.xml",
+          "type": "application/xml"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #55

## Summary

- Adds a `Link: </.well-known/api-catalog>; rel="api-catalog"` response header to all CloudFront responses via a new `ResponseHeadersPolicy` resource
- Creates `/.well-known/api-catalog` — a [RFC 9727](https://www.rfc-editor.org/rfc/rfc9727) linkset document pointing agents to the about page and sitemap

## How it works

**CloudFormation (`infra/cloudformation.yaml`)**:
- New `ResponseHeadersPolicy` resource adds the `Link` header on every CloudFront response
- The policy is wired into `DefaultCacheBehavior.ResponseHeadersPolicyId`

**Static asset (`website/public/.well-known/api-catalog`)**:
- JSON linkset document in `application/linkset+json` format
- Served at `/.well-known/api-catalog` — the existing CloudFront URL-rewrite function already passes this through correctly since the path contains a dot (`.well-known`)

## Test plan

- [ ] Deploy the CloudFormation stack update — verify `Link` header appears in `curl -I https://recipes.atlow.co.il/`
- [ ] Verify `https://recipes.atlow.co.il/.well-known/api-catalog` returns the linkset JSON
- [ ] Re-run [isitagentready.com](https://isitagentready.com) check — should pass Link header check

🤖 Generated with [Claude Code](https://claude.com/claude-code)