### PR TITLE
feat: Markdown for Agents — serve text/markdown to AI clients

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,8 @@ jobs:
             --delete \
             --cache-control "public, max-age=31536000, immutable" \
             --exclude "*.html" \
-            --exclude "*.json"
+            --exclude "*.json" \
+            --exclude "*.md"
           # HTML files (short cache)
           aws s3 sync website/out/ s3://recipes.atlow.co.il \
             --cache-control "public, max-age=60, s-maxage=3600" \
@@ -68,6 +69,13 @@ jobs:
             --exclude "*" \
             --include "*.json" \
             --content-type "application/json" \
+            --no-guess-mime-type
+          # Markdown files for AI agents (short cache, explicit content-type)
+          aws s3 sync website/out/ s3://recipes.atlow.co.il \
+            --cache-control "public, max-age=60, s-maxage=3600" \
+            --exclude "*" \
+            --include "*.md" \
+            --content-type "text/markdown" \
             --no-guess-mime-type
 
       - name: Invalidate CloudFront cache

--- a/infra/cloudformation.yaml
+++ b/infra/cloudformation.yaml
@@ -84,10 +84,12 @@ Resources:
           if (uri === '/') {
             return request;
           }
+          var accept = request.headers['accept'] ? request.headers['accept'].value : '';
+          var ext = accept.indexOf('text/markdown') !== -1 ? '.md' : '.html';
           if (uri.endsWith('/')) {
-            request.uri = uri.slice(0, -1) + '.html';
+            request.uri = uri.slice(0, -1) + ext;
           } else if (!uri.includes('.')) {
-            request.uri += '.html';
+            request.uri += ext;
           }
           return request;
         }

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "prebuild": "node --experimental-strip-types --no-warnings scripts/optimize-images.ts",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "postbuild": "node --experimental-strip-types --no-warnings scripts/generate-markdown.ts"
   },
   "dependencies": {
     "embla-carousel-react": "^8.6.0",

--- a/website/scripts/generate-markdown.ts
+++ b/website/scripts/generate-markdown.ts
@@ -1,0 +1,104 @@
+/**
+ * Post-build script: generates .md versions of all recipe pages in out/.
+ * These are served when a request includes Accept: text/markdown (AI agents).
+ */
+
+import { readFileSync, readdirSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+
+const RECIPES_DIR = resolve(import.meta.dirname, '../../data/recipes');
+const OUT_DIR = resolve(import.meta.dirname, '../out');
+
+interface Recipe {
+  slug: string;
+  title: { en: string; he: string };
+  description: { en: string; he: string };
+  ingredients: Array<{ en: string; he: string }>;
+  instructions: { en: string[]; he: string[] };
+  tags: Array<{ en: string; he: string }>;
+}
+
+type Locale = 'en' | 'he';
+
+function loadRecipes(): Recipe[] {
+  if (!existsSync(RECIPES_DIR)) return [];
+  const slugCounts = new Map<string, number>();
+  return readdirSync(RECIPES_DIR)
+    .filter((f) => f.endsWith('.json') && !f.startsWith('.') && f !== 'index.json')
+    .map((f) => {
+      const recipe = JSON.parse(readFileSync(resolve(RECIPES_DIR, f), 'utf-8')) as Recipe;
+      const count = (slugCounts.get(recipe.slug) ?? 0) + 1;
+      slugCounts.set(recipe.slug, count);
+      if (count > 1) recipe.slug = recipe.slug + '-' + count;
+      return recipe;
+    });
+}
+
+function write(filePath: string, content: string) {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(filePath, content, 'utf-8');
+}
+
+function recipeMarkdown(recipe: Recipe, locale: Locale): string {
+  const url = 'https://recipes.atlow.co.il/' + locale + '/recipe/' + recipe.slug;
+  const ingredients = recipe.ingredients.map((i) => '- ' + i[locale]).join('
+');
+  const instructions = recipe.instructions[locale].map((s, i) => (i + 1) + '. ' + s).join('
+');
+  const tags = recipe.tags.map((t) => t[locale]).join(', ');
+  return '# ' + recipe.title[locale] + '
+
+' +
+    recipe.description[locale] + '
+
+' +
+    '**Tags:** ' + tags + '
+
+' +
+    '## Ingredients
+
+' + ingredients + '
+
+' +
+    '## Instructions
+
+' + instructions + '
+
+' +
+    '---
+Source: ' + url + '
+';
+}
+
+function indexMarkdown(recipes: Recipe[], locale: Locale): string {
+  const base = 'https://recipes.atlow.co.il';
+  const heading = locale === 'he' ? 'מתכונים של סבתא' : "Savta's Recipes";
+  const intro = locale === 'he'
+    ? 'מתכונים בכתב יד של סבתא, ממוינים ומתורגמים.'
+    : "Grandmother's handwritten recipes, digitized and translated.";
+  const list = recipes.map((r) => '- [' + r.title[locale] + '](' + base + '/' + locale + '/recipe/' + r.slug + ')').join('
+');
+  return '# ' + heading + '
+
+' + intro + '
+
+## Recipes
+
+' + list + '
+
+---
+Source: ' + base + '/' + locale + '
+';
+}
+
+const recipes = loadRecipes();
+
+for (const locale of ['en', 'he'] as Locale[]) {
+  write(resolve(OUT_DIR, locale + '.md'), indexMarkdown(recipes, locale));
+  for (const recipe of recipes) {
+    write(resolve(OUT_DIR, locale + '/recipe/' + recipe.slug + '.md'), recipeMarkdown(recipe, locale));
+  }
+}
+
+console.log('Generated markdown for ' + recipes.length + ' recipes x 2 locales + 2 index pages');


### PR DESCRIPTION
## Summary

Fixes #56 — adds content negotiation so AI agents receive clean Markdown instead of HTML.

- **`website/scripts/generate-markdown.ts`** — new postbuild script that reads recipe JSON and generates `.md` files for every locale/recipe page (e.g. `out/en/recipe/shortbread-cookies.md`) plus index pages (`out/en.md`, `out/he.md`)
- **`website/package.json`** — adds `postbuild` hook so markdown files are produced automatically after every `next build`
- **`infra/cloudformation.yaml`** — updates the CloudFront viewer-request function to inspect the `Accept` header: routes to `.md` when `text/markdown` is present, `.html` otherwise (no change for browsers)
- **`.github/workflows/deploy.yml`** — adds an `aws s3 sync` pass that uploads `*.md` files with `Content-Type: text/markdown` and a short cache TTL; also excludes `*.md` from the long-cache static-assets pass

## How it works

```
GET /en/recipe/shortbread-cookies
Accept: text/markdown
→ CloudFront function rewrites to /en/recipe/shortbread-cookies.md
→ S3 returns Content-Type: text/markdown
```

Browsers continue to receive `text/html` (their `Accept` header never contains `text/markdown`).

## Test plan

- [ ] Run `npm run build` in `website/` — confirm `postbuild` generates `.md` files in `out/`
- [ ] Spot-check `out/en/recipe/shortbread-cookies.md` for correct title, ingredients, instructions
- [ ] After deploy: `curl -H "Accept: text/markdown" https://recipes.atlow.co.il/en/recipe/shortbread-cookies` — expect `Content-Type: text/markdown` response
- [ ] Normal browser request still returns HTML (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)