### PR TITLE
fix: prioritize above-fold images and preload hero to improve LCP

### DIFF
--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -104,6 +104,7 @@ export default async function RecipeGrid({
             tags={recipe.tags}
             locale={locale}
             index={i}
+            priority={i < 4}
           />
         ))}
       </div>

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -55,6 +55,7 @@ export default function RootLayout({
     >
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="preload" href="/savta.webp" as="image" type="image/webp" />
       </head>
       <body className="min-h-screen antialiased">
         <MobileTapFix />

--- a/website/components/RecipeCard.tsx
+++ b/website/components/RecipeCard.tsx
@@ -10,6 +10,7 @@ interface RecipeCardProps {
   tags?: Array<{ en: string; he: string }>;
   locale: Locale;
   index?: number;
+  priority?: boolean;
 }
 
 export default function RecipeCard({
@@ -19,6 +20,7 @@ export default function RecipeCard({
   tags,
   locale,
   index = 0,
+  priority = false,
 }: RecipeCardProps) {
   return (
     <Link
@@ -35,6 +37,7 @@ export default function RecipeCard({
         fill
         className="object-cover transition-transform duration-500 ease-out [@media(hover:hover)]:group-hover:scale-[1.04]"
         sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+        priority={priority}
       />
 
       {/* Frosted glass title band */}


### PR DESCRIPTION
## Summary

Fixes PageSpeed LCP and image loading issues reported in #61:

- **`RecipeCard.tsx`**: Added `priority` prop (forwarded to Next.js `<Image>`), enabling callers to opt specific cards into eager loading with `fetchpriority="high"`.
- **`app/[locale]/page.tsx`**: Passes `priority={i < 4}` to the first four recipe cards in the grid — these are above-the-fold on all screen sizes and are the most likely LCP candidates. Previously they defaulted to `loading="lazy"` with no `fetchpriority`, which Lighthouse flagged.
- **`app/layout.tsx`**: Adds `<link rel="preload">` for `/savta.webp` in the root `<head>` so the browser discovers the hero portrait image immediately from HTML rather than waiting for React to render it.

These changes address the two actionable Lighthouse findings:
- _"fetchpriority=high should be applied"_ → first 4 cards now get this via the `priority` prop
- _"lazy load not applied / LCP image discoverable from HTML"_ → preload hint + no lazy loading on above-fold cards

The render-blocking CSS item (#3 in the issue) is harder to address with `output: "export"` — it would require `experimental.optimizeCss` with the `critters` package, which needs further investigation for compatibility with the static export mode.

## Test plan

- [ ] Run `npm run build` in `website/` and verify the build succeeds
- [ ] Load the home page and check DevTools Network tab: first 4 recipe card images should show `fetchpriority: high` and no `loading="lazy"` attribute
- [ ] Verify savta portrait has a corresponding `<link rel="preload">` in the HTML `<head>`
- [ ] Run Lighthouse on the home page and confirm LCP and image diagnostics improve

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)