### PR TITLE
feat(seo): add Content-Signal directives to robots.txt

### DIFF
--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
 Allow: /
 
+Content-Signal: ai-train=no, search=yes, ai-input=no
+
 Sitemap: https://recipes.atlow.co.il/sitemap.xml


### PR DESCRIPTION
## Summary

- Adds `Content-Signal` directives to `website/public/robots.txt` per the [Content Signals spec](https://contentsignals.org/)
- Declares `ai-train=no` to opt out of AI training data use
- Declares `search=yes` to allow search indexing
- Declares `ai-input=no` to opt out of use as AI model input

## Test plan

- [ ] Verify `robots.txt` is accessible at `https://recipes.atlow.co.il/robots.txt` after deploy
- [ ] Confirm the `Content-Signal` line is present and correctly formatted

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)