### PR TITLE
feat: publish OAuth Protected Resource Metadata (RFC 9728)

### DIFF
--- a/website/public/.well-known/oauth-protected-resource
+++ b/website/public/.well-known/oauth-protected-resource
@@ -1,0 +1,6 @@
+{
+  "resource": "https://recipes.atlow.co.il",
+  "authorization_servers": [],
+  "scopes_supported": [],
+  "bearer_methods_supported": []
+}


### PR DESCRIPTION
## Summary

- Adds `/.well-known/oauth-protected-resource` to `website/public/.well-known/` per [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)
- Sets `resource` to `https://recipes.atlow.co.il` (the site's canonical URL)
- Sets `authorization_servers`, `scopes_supported`, and `bearer_methods_supported` to empty arrays, explicitly indicating **no resources are OAuth-protected** — this site is fully public

## Why

Agents and API clients can discover authentication requirements by fetching `/.well-known/oauth-protected-resource`. Without this file, agents have no standard signal about whether tokens are needed. Publishing it with empty arrays clearly communicates that no access tokens are required.

## Test plan

- [ ] Visit `https://recipes.atlow.co.il/.well-known/oauth-protected-resource` after deploy and confirm it returns the JSON with empty arrays
- [ ] Confirm the static export includes the file under `out/.well-known/oauth-protected-resource`

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)