### PR TITLE
feat(infra): add Vary: Accept header for markdown content negotiation

### DIFF
--- a/infra/cloudformation.yaml
+++ b/infra/cloudformation.yaml
@@ -116,11 +116,14 @@ Resources:
     Properties:
       ResponseHeadersPolicyConfig:
         Name: !Sub "${AWS::StackName}-agent-ready"
-        Comment: RFC 8288 Link header for agent discovery (RFC 9727)
+        Comment: RFC 8288 Link header for agent discovery (RFC 9727) + Vary for markdown negotiation
         CustomHeadersConfig:
           Items:
             - Header: Link
               Value: '</.well-known/api-catalog>; rel="api-catalog"'
+              Override: false
+            - Header: Vary
+              Value: Accept
               Override: false
 
   # ── CloudFront Distribution ──


### PR DESCRIPTION
## Summary

- Adds `Vary: Accept` to the CloudFront `ResponseHeadersPolicy` so browsers and downstream caches know that responses differ by `Accept` header
- Completes RFC-compliant HTTP content negotiation for Markdown for Agents

## How it works

The stack already had all the pieces in place:
- A CloudFront viewer-request function that rewrites extensionless URLs to `.md` when `Accept: text/markdown` is present (or `.html` otherwise)
- A postbuild script that generates `.md` versions of every recipe page
- The deploy pipeline uploads those `.md` files to S3 with `Content-Type: text/markdown`

The missing link was the `Vary: Accept` response header. Without it, browsers and intermediary proxies had no signal that the same URL can return different content types, breaking standard content negotiation semantics.

## Test plan

- [ ] Deploy and request a recipe page with `Accept: text/markdown` — should receive `Content-Type: text/markdown` markdown body
- [ ] Confirm `Vary: Accept` is present in the response headers
- [ ] Regular browser request (no `Accept: text/markdown`) still returns HTML
- [ ] Run isitagentready.com check against the site

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)