### PR TITLE
feat: add MCP Server Card for agent discovery

### DIFF
--- a/website/public/.well-known/mcp-server-card
+++ b/website/public/.well-known/mcp-server-card
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json",
+  "name": "il.co.atlow/savtas-recipes",
+  "version": "1.0.0",
+  "title": "Savta's Recipes",
+  "description": "Bilingual (English/Hebrew) recipe collection digitised from handwritten originals",
+  "websiteUrl": "https://recipes.atlow.co.il",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://recipes.atlow.co.il/mcp",
+      "supportedProtocolVersions": ["2025-03-26", "2025-06-18"]
+    }
+  ]
+}

--- a/website/public/.well-known/mcp/server-card.json
+++ b/website/public/.well-known/mcp/server-card.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json",
+  "name": "il.co.atlow/savtas-recipes",
+  "version": "1.0.0",
+  "title": "Savta's Recipes",
+  "description": "Bilingual (English/Hebrew) recipe collection digitised from handwritten originals",
+  "websiteUrl": "https://recipes.atlow.co.il",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://recipes.atlow.co.il/mcp",
+      "supportedProtocolVersions": ["2025-03-26", "2025-06-18"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `/.well-known/mcp/server-card.json` as requested in the issue
- Also adds `/.well-known/mcp-server-card` (the canonical path per SEP-2127 spec)
- Both files expose the server's identity (`name`, `version`), a `streamable-http` transport endpoint at `https://recipes.atlow.co.il/mcp`, and supported MCP protocol versions

## Schema

The server card follows the [SEP-2127 MCP Server Cards](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127) draft specification, using the `https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json` schema.

## Test plan

- [ ] Verify `/.well-known/mcp/server-card.json` returns valid JSON with `name`, `version`, `remotes[].url`, and `supportedProtocolVersions`
- [ ] Verify `/.well-known/mcp-server-card` returns the same content (spec-canonical path)
- [ ] Run isitagentready.com check against the deployed site

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)