### PR TITLE
feat: implement WebMCP to expose recipe tools to AI agents

### DIFF
--- a/website/app/[locale]/layout.tsx
+++ b/website/app/[locale]/layout.tsx
@@ -1,5 +1,7 @@
 import Navbar from "@/components/Navbar";
-import type { Locale } from "@/lib/recipes";
+import WebMCPProvider from "@/components/WebMCPProvider";
+import { getAllRecipes, type Locale } from "@/lib/recipes";
+import { buildSearchIndex } from "@/lib/search";
 
 export function generateStaticParams() {
   return [{ locale: "en" }, { locale: "he" }];
@@ -15,10 +17,12 @@ export default async function LocaleLayout({
   const { locale: localeParam } = await params;
   const locale = localeParam as Locale;
   const isHebrew = locale === "he";
+  const searchIndex = buildSearchIndex(getAllRecipes());
 
   return (
     <div dir={isHebrew ? "rtl" : "ltr"} lang={locale}>
       <Navbar locale={locale} />
+      <WebMCPProvider recipes={searchIndex} locale={locale} />
       <main className="max-w-6xl mx-auto px-4 sm:px-6 py-8">
         {children}
       </main>

--- a/website/components/WebMCPProvider.tsx
+++ b/website/components/WebMCPProvider.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect } from "react";
+import { createFuse, type SearchableRecipe } from "@/lib/search";
+import type { Locale } from "@/lib/recipes";
+
+interface WebMCPProviderProps {
+  recipes: SearchableRecipe[];
+  locale: Locale;
+}
+
+export default function WebMCPProvider({ recipes, locale }: WebMCPProviderProps) {
+  useEffect(() => {
+    const nav = navigator as Navigator & {
+      modelContext?: {
+        provideContext: (ctx: unknown) => void;
+      };
+    };
+
+    if (!nav.modelContext?.provideContext) return;
+
+    const fuse = createFuse(recipes);
+
+    nav.modelContext.provideContext({
+      tools: [
+        {
+          name: "search_recipes",
+          description:
+            "Search Savta's recipe collection by name, ingredient, or tag. Returns matching recipes with slugs and URLs.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: {
+                type: "string",
+                description: "Search query — recipe name, ingredient, or tag",
+              },
+            },
+            required: ["query"],
+          },
+          execute: (params: { query: string }) => {
+            const results = fuse
+              .search(params.query)
+              .slice(0, 10)
+              .map((r) => ({
+                slug: r.item.slug,
+                titleEn: r.item.titleEn,
+                titleHe: r.item.titleHe,
+                tags: locale === "he" ? r.item.tagsHe : r.item.tagsEn,
+                url: `/${locale}/recipe/${r.item.slug}`,
+              }));
+            return { results };
+          },
+        },
+        {
+          name: "list_all_recipes",
+          description:
+            "List every recipe in Savta's collection with names, tags, and page URLs.",
+          inputSchema: {
+            type: "object",
+            properties: {},
+          },
+          execute: () => ({
+            recipes: recipes.map((r) => ({
+              slug: r.slug,
+              titleEn: r.titleEn,
+              titleHe: r.titleHe,
+              tags: locale === "he" ? r.tagsHe : r.tagsEn,
+              url: `/${locale}/recipe/${r.slug}`,
+            })),
+          }),
+        },
+        {
+          name: "navigate_to_recipe",
+          description: "Navigate the browser to a specific recipe page.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              slug: {
+                type: "string",
+                description: "Recipe slug from search_recipes or list_all_recipes",
+              },
+            },
+            required: ["slug"],
+          },
+          execute: (params: { slug: string }) => {
+            const url = `/${locale}/recipe/${params.slug}`;
+            window.location.href = url;
+            return { navigating: true, url };
+          },
+        },
+        {
+          name: "navigate_to_search",
+          description:
+            "Navigate to the recipe search page, optionally pre-filled with a query.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: {
+                type: "string",
+                description: "Optional search query to pre-fill",
+              },
+            },
+          },
+          execute: (params: { query?: string }) => {
+            const url = `/${locale}/search${params.query ? `?q=${encodeURIComponent(params.query)}` : ""}`;
+            window.location.href = url;
+            return { navigating: true, url };
+          },
+        },
+      ],
+    });
+  }, [recipes, locale]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Adds `WebMCPProvider` client component that calls `navigator.modelContext.provideContext()` on mount in all locale pages
- Registers four browser-side tools: `search_recipes`, `list_all_recipes`, `navigate_to_recipe`, and `navigate_to_search`
- Gracefully no-ops in browsers that don't support WebMCP (`navigator.modelContext` not present)
- Locale layout updated to pass the recipe search index (already computed at build time) to the provider

## Tools exposed

| Tool | Description |
|------|-------------|
| `search_recipes` | Fuzzy-search by name, ingredient, or tag using Fuse.js |
| `list_all_recipes` | Return all recipes with slugs, bilingual titles, tags, and URLs |
| `navigate_to_recipe` | Navigate the browser to a specific recipe page by slug |
| `navigate_to_search` | Navigate to the search page with an optional pre-filled query |

## Test plan

- [ ] Open the site in a WebMCP-capable browser (Chrome with WebMCP extension or flag)
- [ ] Verify `navigator.modelContext.provideContext` is called without errors
- [ ] Test `search_recipes` returns relevant results for a query like "chocolate"
- [ ] Test `navigate_to_recipe` navigates correctly
- [ ] Verify non-WebMCP browsers load the page without errors

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)