### PR TITLE
feat(website): implement WebMCP to expose recipe tools to AI agents

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Heebo, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import MobileTapFix from "@/components/MobileTapFix";
+import WebMCPProvider from "@/components/WebMCPProvider";
+import { getRecipesIndex } from "@/lib/recipes";
 
 const heebo = Heebo({
   subsets: ["hebrew", "latin"],
@@ -48,6 +50,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const recipesIndex = getRecipesIndex();
   return (
     <html
       lang="en"
@@ -59,6 +62,7 @@ export default function RootLayout({
       </head>
       <body className="min-h-screen antialiased">
         <MobileTapFix />
+        <WebMCPProvider recipes={recipesIndex} />
         {children}
       </body>
     </html>

--- a/website/components/WebMCPProvider.tsx
+++ b/website/components/WebMCPProvider.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect } from "react";
+import type { RecipeIndex } from "@/lib/recipes";
+
+interface WebMCPTool {
+  name: string;
+  description: string;
+  inputSchema: object;
+  execute: (input: Record<string, unknown>) => Promise<unknown>;
+}
+
+interface ModelContext {
+  provideContext: (options: { tools: WebMCPTool[] }) => Promise<void>;
+}
+
+export default function WebMCPProvider({
+  recipes,
+}: {
+  recipes: RecipeIndex[];
+}) {
+  useEffect(() => {
+    const modelContext = (
+      navigator as Navigator & { modelContext?: ModelContext }
+    ).modelContext;
+    if (!modelContext) return;
+
+    modelContext.provideContext({
+      tools: [
+        {
+          name: "list_recipes",
+          description:
+            "List all recipes available on Savta's Recipes — a collection of grandmother's handwritten recipes, digitized and translated into English and Hebrew.",
+          inputSchema: {
+            type: "object",
+            properties: {},
+          },
+          execute: async () => recipes,
+        },
+        {
+          name: "search_recipes",
+          description:
+            "Search for recipes by name, ingredient, or tag across Savta's bilingual recipe collection.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: {
+                type: "string",
+                description:
+                  "Search term to match against recipe names, descriptions, and tags (English or Hebrew)",
+              },
+            },
+            required: ["query"],
+          },
+          execute: async (input) => {
+            const query = String(input.query ?? "").toLowerCase();
+            return recipes.filter(
+              (r) =>
+                r.titleEn.toLowerCase().includes(query) ||
+                r.titleHe.includes(query) ||
+                r.descriptionEn.toLowerCase().includes(query) ||
+                r.tags.some((t) => t.toLowerCase().includes(query))
+            );
+          },
+        },
+        {
+          name: "get_recipe_url",
+          description:
+            "Get the URL for a specific recipe page given its slug and preferred language.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              slug: {
+                type: "string",
+                description: "The recipe slug (URL identifier)",
+              },
+              locale: {
+                type: "string",
+                enum: ["en", "he"],
+                description: "Language preference — 'en' (English) or 'he' (Hebrew). Defaults to 'en'.",
+              },
+            },
+            required: ["slug"],
+          },
+          execute: async (input) => {
+            const slug = String(input.slug ?? "");
+            const locale = input.locale === "he" ? "he" : "en";
+            const recipe = recipes.find((r) => r.slug === slug);
+            if (!recipe) return { error: `Recipe '${slug}' not found` };
+            return {
+              slug,
+              url: `/${locale}/recipe/${slug}`,
+              title: locale === "he" ? recipe.titleHe : recipe.titleEn,
+            };
+          },
+        },
+      ],
+    });
+  }, [recipes]);
+
+  return null;
+}

--- a/website/lib/recipes.ts
+++ b/website/lib/recipes.ts
@@ -57,3 +57,25 @@ export function getAllSlugs(): string[] {
   return getAllRecipes().map((r) => r.slug);
 }
 
+export interface RecipeIndex {
+  slug: string;
+  titleEn: string;
+  titleHe: string;
+  descriptionEn: string;
+  descriptionHe: string;
+  tags: string[];
+  illustration: string;
+}
+
+export function getRecipesIndex(): RecipeIndex[] {
+  return getAllRecipes().map((r) => ({
+    slug: r.slug,
+    titleEn: r.title.en,
+    titleHe: r.title.he,
+    descriptionEn: r.description.en,
+    descriptionHe: r.description.he,
+    tags: r.tags.map((t) => t.en),
+    illustration: r.illustration,
+  }));
+}
+


### PR DESCRIPTION
## Summary

- Adds `WebMCPProvider` client component that calls `navigator.modelContext.provideContext()` on mount, registering the site's key actions as tools for AI agents
- Exposes three tools: `list_recipes` (all recipes), `search_recipes` (filter by name/tag/description in English or Hebrew), and `get_recipe_url` (resolve a slug to a page URL with locale support)
- Recipe data is serialized at build time via a new `getRecipesIndex()` helper in `lib/recipes.ts` and passed as props — no runtime fetch required
- The component renders `null` and gracefully no-ops in browsers without `navigator.modelContext`

## Test plan

- [ ] Build the site (`npm run build` in `website/`) — should compile with no TypeScript errors
- [ ] Open in a WebMCP-capable browser and confirm `navigator.modelContext.provideContext()` is called on page load
- [ ] Verify `list_recipes` returns all recipe objects
- [ ] Verify `search_recipes({ query: "cake" })` returns matching recipes
- [ ] Verify `get_recipe_url({ slug: "<valid-slug>" })` returns the correct URL
- [ ] Verify `get_recipe_url({ slug: "nonexistent" })` returns `{ error: "..." }`
- [ ] Confirm no regressions in normal browser usage (component is invisible and side-effect-only)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)