### PR TITLE
perf: fix Pingdom F0 gzip and C72 HTTP request findings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,34 +49,80 @@ jobs:
 
       - name: Sync to S3
         run: |
-          # Static assets (long cache)
+          # Pre-gzip all text assets in-place so S3 serves them compressed
+          find website/out -type f \( -name "*.html" -o -name "*.css" -o -name "*.js" -o -name "*.json" -o -name "*.svg" -o -name "*.md" \) \
+            -exec sh -c 'gzip -9 "$1" && mv "${1}.gz" "$1"' _ {} \;
+
+          # Binary assets (images, fonts) — no compression, auto content-type
           aws s3 sync website/out/ s3://recipes.atlow.co.il \
             --delete \
             --cache-control "public, max-age=31536000, immutable" \
             --exclude "*.html" \
+            --exclude "*.css" \
+            --exclude "*.js" \
             --exclude "*.json" \
+            --exclude "*.svg" \
             --exclude "*.md"
-          # HTML files (short cache)
+
+          # CSS (long cache, gzip-encoded)
           aws s3 sync website/out/ s3://recipes.atlow.co.il \
-            --cache-control "public, max-age=60, s-maxage=3600" \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --content-type "text/css" \
+            --content-encoding "gzip" \
+            --no-guess-mime-type \
             --exclude "*" \
-            --include "*.html" \
+            --include "*.css"
+
+          # JavaScript (long cache, gzip-encoded)
+          aws s3 sync website/out/ s3://recipes.atlow.co.il \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --content-type "text/javascript" \
+            --content-encoding "gzip" \
+            --no-guess-mime-type \
+            --exclude "*" \
+            --include "*.js"
+
+          # SVG (long cache, gzip-encoded)
+          aws s3 sync website/out/ s3://recipes.atlow.co.il \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --content-type "image/svg+xml" \
+            --content-encoding "gzip" \
+            --no-guess-mime-type \
+            --exclude "*" \
+            --include "*.svg"
+
+          # HTML (short cache, gzip-encoded)
+          aws s3 sync website/out/ s3://recipes.atlow.co.il \
+            --delete \
+            --cache-control "public, max-age=60, s-maxage=3600" \
             --content-type "text/html" \
-            --no-guess-mime-type
-          # JSON files (short cache)
-          aws s3 sync website/out/ s3://recipes.atlow.co.il \
-            --cache-control "public, max-age=60, s-maxage=3600" \
+            --content-encoding "gzip" \
+            --no-guess-mime-type \
             --exclude "*" \
-            --include "*.json" \
+            --include "*.html"
+
+          # JSON (short cache, gzip-encoded)
+          aws s3 sync website/out/ s3://recipes.atlow.co.il \
+            --delete \
+            --cache-control "public, max-age=60, s-maxage=3600" \
             --content-type "application/json" \
-            --no-guess-mime-type
-          # Markdown files for AI agents (short cache, explicit content-type)
-          aws s3 sync website/out/ s3://recipes.atlow.co.il \
-            --cache-control "public, max-age=60, s-maxage=3600" \
+            --content-encoding "gzip" \
+            --no-guess-mime-type \
             --exclude "*" \
-            --include "*.md" \
+            --include "*.json"
+
+          # Markdown (short cache, gzip-encoded)
+          aws s3 sync website/out/ s3://recipes.atlow.co.il \
+            --delete \
+            --cache-control "public, max-age=60, s-maxage=3600" \
             --content-type "text/markdown" \
-            --no-guess-mime-type
+            --content-encoding "gzip" \
+            --no-guess-mime-type \
+            --exclude "*" \
+            --include "*.md"
 
       - name: Invalidate CloudFront cache
         run: |

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -5,6 +5,15 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true, // Required for static export
   },
+  webpack(config, { isServer }) {
+    if (!isServer) {
+      const sc = config.optimization?.splitChunks;
+      if (sc && typeof sc === "object") {
+        sc.maxInitialRequests = 4;
+      }
+    }
+    return config;
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Addresses the two Pingdom speed test findings from issue #53:

- **F0 gzip**: The previous deploy pipeline relied on CloudFront's on-the-fly compression (`Compress: true`), which wasn't reliably applying gzip to all text assets. The fix pre-compresses every text file (HTML, CSS, JS, JSON, SVG, MD) with `gzip -9` before upload and sets explicit `Content-Encoding: gzip` + correct `Content-Type` headers per file type on the S3 object. CloudFront forwards these headers unchanged, so browsers always receive compressed content regardless of edge-cache state.

- **C72 HTTP requests**: Next.js's default webpack config splits code into many small chunks (up to 25 initial requests). Capping `maxInitialRequests` at 4 in `next.config.ts` consolidates vendor and page code into fewer files, directly reducing the request count Pingdom measures.

**Bonus**: Each text-type `aws s3 sync` now carries `--delete`, so stale files of each type are cleaned up independently (previously only binary assets were cleaned up by the first sync).

## Test plan

- [ ] Deploy workflow completes without error
- [ ] `curl -I https://recipes.atlow.co.il` shows `Content-Encoding: gzip` on HTML response
- [ ] `curl -I https://recipes.atlow.co.il/_next/static/...css` shows `Content-Encoding: gzip`
- [ ] Re-run Pingdom test — gzip grade improves from F0; HTTP request grade improves from C72
- [ ] Site loads and functions correctly in browser (recipes browsable, search works)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)