### PR TITLE
Reduce legacy JavaScript: target modern browsers in SWC/Next.js

### DIFF
--- a/website/.browserslistrc
+++ b/website/.browserslistrc
@@ -1,4 +1,4 @@
-last 2 Chrome versions
-last 2 Firefox versions
-last 2 Safari versions
-last 2 Edge versions
+chrome >= 109
+firefox >= 109
+safari >= 16
+edge >= 109

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -5,6 +5,9 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true, // Required for static export
   },
+  experimental: {
+    browsersListForSwc: true,
+  },
   webpack(config, { isServer }) {
     if (!isServer) {
       const sc = config.optimization?.splitChunks;

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Lighthouse audit (issue #79) flagged ~12 KiB of unnecessary legacy JavaScript in the production bundle, including:

- `@babel/plugin-transform-classes` — ES6 classes rewritten to prototype chains
- `@babel/plugin-transform-spread` — spread syntax rewritten to `.apply()`
- Polyfills for `Array.prototype.at/flat/flatMap`, `Object.fromEntries`, `Object.hasOwn`, `String.prototype.trimStart/trimEnd`

All of these features ship natively in every browser we target, so there's no reason to compile them away.

### Changes

| File | Change |
|---|---|
| `website/tsconfig.json` | `target`: `ES2017` → `ES2022` — tells SWC it can emit modern class/field syntax |
| `website/next.config.ts` | `experimental.browsersListForSwc: true` — passes browserslist to SWC so it respects our targets for polyfill decisions |
| `website/.browserslistrc` | Replace vague `"last 2 X versions"` with explicit minimums: Chrome/Firefox/Edge ≥ 109, Safari ≥ 16 |

The pinned versions (released late 2022–early 2023) all natively support ES2019–ES2022 features, so SWC will no longer inject the flagged transforms or polyfills.

## Test plan

- [ ] `npm run build` in `website/` succeeds without errors
- [ ] Verify the built JS bundles no longer contain `_classCallCheck`, `_createClass`, or the polyfill strings flagged by Lighthouse
- [ ] Run Lighthouse on the deployed site and confirm the "Reduce Legacy JavaScript" audit passes

Closes #79