### PR TITLE
Enable Markdown for Agents via CloudFront viewer-response function

### DIFF
--- a/infra/cloudformation.yaml
+++ b/infra/cloudformation.yaml
@@ -95,6 +95,24 @@ Resources:
         }
 
 
+  # -- CloudFront Function (set Content-Type: text/markdown for .md responses) --
+  MarkdownResponseFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: !Sub "${AWS::StackName}-markdown-ct"
+      AutoPublish: true
+      FunctionConfig:
+        Comment: Set text/markdown Content-Type for .md responses (Markdown for Agents)
+        Runtime: cloudfront-js-2.0
+      FunctionCode: |
+        function handler(event) {
+          var response = event.response;
+          if (event.request.uri.endsWith('.md')) {
+            response.headers['content-type'] = { value: 'text/markdown; charset=utf-8' };
+          }
+          return response;
+        }
+
   # -- CloudFront Function (set Content-Type for /.well-known/api-catalog) --
   ApiCatalogContentTypeFunction:
     Type: AWS::CloudFront::Function
@@ -159,6 +177,8 @@ Resources:
           FunctionAssociations:
             - EventType: viewer-request
               FunctionARN: !GetAtt UrlRewriteFunction.FunctionARN
+            - EventType: viewer-response
+              FunctionARN: !GetAtt MarkdownResponseFunction.FunctionARN
         # SPA fallback: serve index.html for 404s (Next.js static export)
         CustomErrorResponses:
           - ErrorCode: 403


### PR DESCRIPTION
## Summary

- Adds a new `MarkdownResponseFunction` CloudFront Function that runs as a viewer-response handler
- When the request URI ends with `.md` (i.e., the viewer-request `UrlRewriteFunction` already detected `Accept: text/markdown` and rewrote the path), the response receives `Content-Type: text/markdown; charset=utf-8`
- Associates the new function with the `DefaultCacheBehavior` as a `viewer-response` event

## How it works

The existing `UrlRewriteFunction` (viewer-request) already rewrites URIs for agents:
- `GET /en/recipe/slug` + `Accept: text/markdown` → `GET /en/recipe/slug.md` from S3

The new `MarkdownResponseFunction` (viewer-response) completes the negotiation:
- Sees the rewritten URI ending in `.md`
- Sets `Content-Type: text/markdown; charset=utf-8` on the response

The existing `ResponseHeadersPolicy` already adds `Vary: Accept`, so CDN and proxy caches correctly separate markdown and HTML cache entries.

## Test plan

- [ ] Deploy updated CloudFormation stack
- [ ] `curl -H "Accept: text/markdown" https://recipes.atlow.co.il/en/recipe/<slug>` returns `Content-Type: text/markdown; charset=utf-8`
- [ ] `curl https://recipes.atlow.co.il/en/recipe/<slug>` (no Accept header) still returns `Content-Type: text/html`
- [ ] Response includes `Vary: Accept` header

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)