### PR TITLE
feat: publish agent skills discovery index (RFC v0.2.0)

### DIFF
--- a/website/public/.well-known/agent-skills/browse-recipes/SKILL.md
+++ b/website/public/.well-known/agent-skills/browse-recipes/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: browse-recipes
+type: openapi
+version: 1.0.0
+description: Browse Savta's bilingual recipe collection via REST API
+---
+
+# browse-recipes
+
+Browse and search Savta's bilingual (English/Hebrew) recipe collection via a REST API described by an OpenAPI 3.1 specification.
+
+## OpenAPI Specification
+
+https://recipes.atlow.co.il/openapi.json
+
+## Description
+
+A static bilingual recipe website digitised from handwritten originals. Provides HTML pages for browsing recipes in English and Hebrew, with client-side full-text search.
+
+## Endpoints
+
+- `GET /{locale}` — Recipe grid (locale: `en` | `he`)
+- `GET /{locale}/recipe/{slug}` — Full recipe detail page
+- `GET /{locale}/search?q={query}` — Search recipes by keyword
+- `GET /health.json` — Service health check

--- a/website/public/.well-known/agent-skills/index.json
+++ b/website/public/.well-known/agent-skills/index.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://agentskills.io/schemas/v0.2.0/index.schema.json",
+  "skills": [
+    {
+      "name": "mcp-recipes",
+      "type": "mcp",
+      "description": "Access Savta's bilingual recipe collection via Model Context Protocol",
+      "url": "https://recipes.atlow.co.il/.well-known/agent-skills/mcp-recipes/SKILL.md",
+      "sha256": "e89ea60ca2ad545a937a9e8cfad77ec1ceedcf0920d2fabf2eb6bd36216976af"
+    },
+    {
+      "name": "browse-recipes",
+      "type": "openapi",
+      "description": "Browse Savta's bilingual recipe collection via REST API",
+      "url": "https://recipes.atlow.co.il/.well-known/agent-skills/browse-recipes/SKILL.md",
+      "sha256": "2be3b1d5d845ca9f0959108d38171565dbaf79a458fc7e8866939057518fa3b1"
+    }
+  ]
+}

--- a/website/public/.well-known/agent-skills/mcp-recipes/SKILL.md
+++ b/website/public/.well-known/agent-skills/mcp-recipes/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: mcp-recipes
+type: mcp
+version: 1.0.0
+description: Access Savta's bilingual recipe collection via Model Context Protocol
+---
+
+# mcp-recipes
+
+Access Savta's bilingual (English/Hebrew) recipe collection via the Model Context Protocol (MCP).
+
+## Endpoint
+
+https://recipes.atlow.co.il/mcp
+
+## Supported Protocol Versions
+
+- 2025-03-26
+- 2025-06-18
+
+## Description
+
+Browse, search, and retrieve grandmother's handwritten recipes digitised into a structured bilingual format. Recipes are available in both English (original) and Hebrew (translated), with ingredients, instructions, and AI-generated illustrations.
+
+## Capabilities
+
+- List all recipes in English or Hebrew
+- Retrieve full recipe details including ingredients and step-by-step instructions
+- Search recipes by name or ingredient


### PR DESCRIPTION
## Summary

- Adds `/.well-known/agent-skills/index.json` with `$schema`, and a `skills` array conforming to the Agent Skills Discovery RFC v0.2.0
- Adds `/.well-known/agent-skills/mcp-recipes/SKILL.md` — describes the MCP endpoint (`https://recipes.atlow.co.il/mcp`)
- Adds `/.well-known/agent-skills/browse-recipes/SKILL.md` — describes the OpenAPI/REST interface
- Each skill entry in the index includes `name`, `type`, `description`, `url`, and a `sha256` digest of the SKILL.md

Fixes the issue where `/.well-known/agent-skills/index.json` returned HTML (404 page) instead of JSON by publishing the file as a static asset under `website/public/`.

## Test plan

- [ ] After deploy, `curl https://recipes.atlow.co.il/.well-known/agent-skills/index.json` returns valid JSON with `Content-Type: application/json`
- [ ] Both SKILL.md files are reachable at their respective URLs
- [ ] sha256 values in index.json match `sha256sum` of the SKILL.md files

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)