### PR TITLE
fix: improve text contrast for WCAG AA accessibility compliance

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -12,7 +12,7 @@
 
   --color-ink: #2C1810;
   --color-ink-secondary: #6B5B4E;
-  --color-ink-tertiary: #A69585;
+  --color-ink-tertiary: #7A6659;
 
   --color-accent: #C4553A;
   --color-accent-hover: #A8432D;


### PR DESCRIPTION
## Summary

- Darken `--color-ink-tertiary` CSS variable from `#A69585` to `#7A6659`
- New value achieves ≥4.5:1 contrast ratio against all backgrounds used in the site (`#FFFFFF`, `#FAF7F2`, `#F0EBE3`)
- Fixes all failing elements reported in the issue: the ⌘K keyboard hint, the "How It Works" nav link, the language toggle inactive buttons, the footer credits text

## Test plan

- [ ] Inspect `⌘K` hint text in search bar — should be clearly legible
- [ ] Check "How It Works" link in navbar
- [ ] Verify inactive language toggle button ("EN" / "עב") contrast
- [ ] Confirm footer "Thanks to Neal Atlow & Stuart Atlow" is readable
- [ ] Run an automated accessibility audit (e.g. axe DevTools) to confirm WCAG AA pass

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)