### PR TITLE
feat: improve AI agent readiness (markdown negotiation, content signals, WebMCP)

### DIFF
--- a/infra/cloudformation.yaml
+++ b/infra/cloudformation.yaml
@@ -81,11 +81,13 @@ Resources:
         function handler(event) {
           var request = event.request;
           var uri = request.uri;
+          var accept = request.headers['accept'] ? request.headers['accept'].value : '';
+          var wantsMarkdown = accept.indexOf('text/markdown') !== -1;
           if (uri === '/') {
+            if (wantsMarkdown) request.uri = '/index.md';
             return request;
           }
-          var accept = request.headers['accept'] ? request.headers['accept'].value : '';
-          var ext = accept.indexOf('text/markdown') !== -1 ? '.md' : '.html';
+          var ext = wantsMarkdown ? '.md' : '.html';
           if (uri.endsWith('/')) {
             request.uri = uri.slice(0, -1) + ext;
           } else if (!uri.includes('.')) {

--- a/website/public/.well-known/agent-skills/content-signals/SKILL.md
+++ b/website/public/.well-known/agent-skills/content-signals/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: content-signals
+type: content-signals
+version: 1.0.0
+description: AI content usage preferences declared via Content-Signal in robots.txt
+---
+
+# content-signals
+
+Savta's Recipes declares its preferences for AI content usage via Content-Signal directives in `robots.txt`, following the [Content Signals](https://contentsignals.org/) specification.
+
+## robots.txt location
+
+https://recipes.atlow.co.il/robots.txt
+
+## Content-Signal directives
+
+```
+Content-Signal: ai-train=no, search=yes, ai-input=no
+```
+
+| Directive    | Value | Meaning                                           |
+|-------------|-------|---------------------------------------------------|
+| `ai-train`  | `no`  | Content must not be used to train AI/ML models   |
+| `search`    | `yes` | Content may be indexed by search engines          |
+| `ai-input`  | `no`  | Content must not be used as AI model input        |

--- a/website/public/.well-known/agent-skills/index.json
+++ b/website/public/.well-known/agent-skills/index.json
@@ -14,6 +14,27 @@
       "description": "Browse Savta's bilingual recipe collection via REST API",
       "url": "https://recipes.atlow.co.il/.well-known/agent-skills/browse-recipes/SKILL.md",
       "sha256": "2be3b1d5d845ca9f0959108d38171565dbaf79a458fc7e8866939057518fa3b1"
+    },
+    {
+      "name": "markdown-negotiation",
+      "type": "markdown",
+      "description": "Get any page as Markdown by sending Accept: text/markdown",
+      "url": "https://recipes.atlow.co.il/.well-known/agent-skills/markdown-negotiation/SKILL.md",
+      "sha256": "98fb95a2b7433a52d6956f200983317ebe2ba0f6ec045920d16f9f130ed5bbf4"
+    },
+    {
+      "name": "content-signals",
+      "type": "content-signals",
+      "description": "AI content usage preferences declared via Content-Signal in robots.txt",
+      "url": "https://recipes.atlow.co.il/.well-known/agent-skills/content-signals/SKILL.md",
+      "sha256": "9f8761de57bfb07720fa394b2699be5570d604ac8ca6a269e51cbc0297527953"
+    },
+    {
+      "name": "webmcp",
+      "type": "webmcp",
+      "description": "Browser-native AI agent tools via navigator.modelContext.provideContext()",
+      "url": "https://recipes.atlow.co.il/.well-known/agent-skills/webmcp/SKILL.md",
+      "sha256": "97a6a6b68e15ef9c0efbe690ce129e6c7649f12e01d914819f9a57e67e8f0488"
     }
   ]
 }

--- a/website/public/.well-known/agent-skills/markdown-negotiation/SKILL.md
+++ b/website/public/.well-known/agent-skills/markdown-negotiation/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: markdown-negotiation
+type: markdown
+version: 1.0.0
+description: Get any page as Markdown by sending Accept: text/markdown
+---
+
+# markdown-negotiation
+
+Savta's Recipes supports HTTP content negotiation. Send `Accept: text/markdown` with any request to receive Markdown instead of HTML.
+
+## How it works
+
+- Add `Accept: text/markdown` to your request headers
+- The server returns the page content as Markdown (`Content-Type: text/markdown; charset=utf-8`)
+- HTML remains the default for browsers; the `Vary: Accept` response header signals caches correctly
+
+## Endpoints with Markdown support
+
+- `GET /` — Site index (links to language versions)
+- `GET /en` — English recipe index
+- `GET /he` — Hebrew recipe index
+- `GET /en/recipe/{slug}` — English recipe detail
+- `GET /he/recipe/{slug}` — Hebrew recipe detail
+
+## Example
+
+```http
+GET /en/recipe/chocolate-cake HTTP/1.1
+Host: recipes.atlow.co.il
+Accept: text/markdown
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/markdown; charset=utf-8
+Vary: Accept
+```

--- a/website/public/.well-known/agent-skills/webmcp/SKILL.md
+++ b/website/public/.well-known/agent-skills/webmcp/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: webmcp
+type: webmcp
+version: 1.0.0
+description: Browser-native AI agent tools via navigator.modelContext.provideContext()
+---
+
+# webmcp
+
+Savta's Recipes exposes browser-native tools to AI agents via the [WebMCP](https://webmachinelearning.github.io/webmcp/) API. When loaded in a browser that supports `navigator.modelContext`, agents can search and navigate recipes without leaving the page.
+
+## Implementation
+
+Tools are registered on every recipe page using `navigator.modelContext.provideContext()`.
+
+## Available tools
+
+### search_recipes
+
+Search the recipe collection by name, ingredient, or tag.
+
+**Input schema:**
+```json
+{ "query": { "type": "string" } }
+```
+
+**Returns:** Up to 10 matching recipes with `slug`, `titleEn`, `titleHe`, `tags`, and `url`.
+
+### list_all_recipes
+
+List every recipe with names, tags, and page URLs.
+
+**Input schema:** `{}`
+
+**Returns:** All recipes with `slug`, `titleEn`, `titleHe`, `tags`, and `url`.
+
+### navigate_to_recipe
+
+Navigate the browser to a specific recipe page.
+
+**Input schema:**
+```json
+{ "slug": { "type": "string" } }
+```
+
+### navigate_to_search
+
+Navigate to the search page, optionally pre-filled with a query.
+
+**Input schema:**
+```json
+{ "query": { "type": "string" } }
+```

--- a/website/scripts/generate-markdown.ts
+++ b/website/scripts/generate-markdown.ts
@@ -86,7 +86,25 @@ Source: ${base}/${locale}
 `;
 }
 
+function rootMarkdown(): string {
+  const base = 'https://recipes.atlow.co.il';
+  return `# Savta's Recipes
+
+Grandmother's handwritten recipes, digitized and translated into English and Hebrew.
+
+## Browse Recipes
+
+- [English recipes](${base}/en)
+- [Hebrew recipes / מתכונים בעברית](${base}/he)
+
+---
+Source: ${base}
+`;
+}
+
 const recipes = loadRecipes();
+
+write(resolve(OUT_DIR, 'index.md'), rootMarkdown());
 
 for (const locale of ['en', 'he'] as Locale[]) {
   write(resolve(OUT_DIR, locale + '.md'), indexMarkdown(recipes, locale));
@@ -95,4 +113,4 @@ for (const locale of ['en', 'he'] as Locale[]) {
   }
 }
 
-console.log('Generated markdown for ' + recipes.length + ' recipes x 2 locales + 2 index pages');
+console.log('Generated markdown for ' + recipes.length + ' recipes x 2 locales + 2 index pages + root index');


### PR DESCRIPTION
## Summary

- **Markdown negotiation**: Register `markdown-negotiation` agent skill documenting that `Accept: text/markdown` returns `Content-Type: text/markdown` responses. Also fix CloudFront URL rewrite to handle the root path (`/`) for markdown requests, and generate `out/index.md` in the post-build script.
- **Content signals**: Register `content-signals` agent skill documenting the existing `Content-Signal: ai-train=no, search=yes, ai-input=no` directives already present in `robots.txt`.
- **WebMCP**: Register `webmcp` agent skill documenting the four browser-native tools (`search_recipes`, `list_all_recipes`, `navigate_to_recipe`, `navigate_to_search`) already implemented in `WebMCPProvider.tsx`.

All three skills are added to `.well-known/agent-skills/index.json` so agents can discover them.

## Test plan

- [ ] `GET /en Accept: text/markdown` → `Content-Type: text/markdown; charset=utf-8` (existing CloudFront function)
- [ ] `GET / Accept: text/markdown` → serves `index.md` (new CloudFront root-path fix)
- [ ] `GET /robots.txt` contains `Content-Signal: ai-train=no, search=yes, ai-input=no`
- [ ] `GET /.well-known/agent-skills/index.json` lists all 5 skills including the three new ones
- [ ] `GET /.well-known/agent-skills/markdown-negotiation/SKILL.md` returns skill documentation
- [ ] After build: `website/out/index.md` exists

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)