### PR TITLE
Fix WebMCP: use router.push to prevent execution context destruction

### DIFF
--- a/website/components/WebMCPProvider.tsx
+++ b/website/components/WebMCPProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { createFuse, type SearchableRecipe } from "@/lib/search";
 import type { Locale } from "@/lib/recipes";
 
@@ -10,6 +11,8 @@ interface WebMCPProviderProps {
 }
 
 export default function WebMCPProvider({ recipes, locale }: WebMCPProviderProps) {
+  const router = useRouter();
+
   useEffect(() => {
     const nav = navigator as Navigator & {
       modelContext?: {
@@ -84,7 +87,7 @@ export default function WebMCPProvider({ recipes, locale }: WebMCPProviderProps)
           },
           execute: (params: { slug: string }) => {
             const url = `/${locale}/recipe/${params.slug}`;
-            window.location.href = url;
+            router.push(url);
             return { navigating: true, url };
           },
         },
@@ -103,13 +106,13 @@ export default function WebMCPProvider({ recipes, locale }: WebMCPProviderProps)
           },
           execute: (params: { query?: string }) => {
             const url = `/${locale}/search${params.query ? `?q=${encodeURIComponent(params.query)}` : ""}`;
-            window.location.href = url;
+            router.push(url);
             return { navigating: true, url };
           },
         },
       ],
     });
-  }, [recipes, locale]);
+  }, [recipes, locale, router]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

- The `navigate_to_recipe` and `navigate_to_search` WebMCP tool execute callbacks were calling `window.location.href = url` synchronously
- This triggered a full page navigation mid-evaluation, destroying the JavaScript execution context before `Runtime.evaluate` could return a result
- The Chrome DevTools Protocol then reported: *"Protocol error (Runtime.evaluate): Execution context was destroyed"*

## Fix

Replace `window.location.href` with Next.js `router.push()` (from `useRouter`) in both navigation tool execute callbacks. `router.push()` initiates a client-side SPA navigation that:
- Returns synchronously, allowing the execute callback to return its value before any navigation occurs
- Does **not** destroy the execution context (no full page reload)
- Lets the WebMCP checker receive the tool result successfully

Also added `router` to the `useEffect` dependency array and imported `useRouter` from `next/navigation`.

## Test plan

- [ ] Open the site in Chrome with WebMCP support enabled
- [ ] Verify `navigator.modelContext` is populated with the four tools
- [ ] Call `navigate_to_recipe` via the model context — confirm navigation works without crashing the context
- [ ] Check with [isitagentready.com](https://isitagentready.com) — WebMCP check should now pass

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)