### PR TITLE
perf(website): fix PageSpeed issues (TBT, LCP, image delivery, critical chain)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ data/illustrations/*-*w.*
 data/illustrations/*-og.png
 data/scans/*-*w.*
 website/public/savta.webp
+website/public/savta.avif
+website/public/savta-og.jpg
+website/public/savta-apple.png
+
+# Website generated artifacts
+website/public/search-index.json
+website/tsconfig.tsbuildinfo

--- a/website/app/[locale]/about/page.tsx
+++ b/website/app/[locale]/about/page.tsx
@@ -10,7 +10,7 @@ export default async function AboutPage({
   const isHebrew = locale === "he";
 
   return (
-    <article className="animate-fade-up max-w-3xl mx-auto py-4">
+    <article className="max-w-3xl mx-auto py-4">
       <h1 className="font-semibold text-3xl text-[var(--color-ink)] mb-2">
         {isHebrew ? "איך זה עובד" : "How It Works"}
       </h1>

--- a/website/app/[locale]/layout.tsx
+++ b/website/app/[locale]/layout.tsx
@@ -1,7 +1,6 @@
 import Navbar from "@/components/Navbar";
 import WebMCPProvider from "@/components/WebMCPProvider";
-import { getAllRecipes, type Locale } from "@/lib/recipes";
-import { buildSearchIndex } from "@/lib/search";
+import { type Locale } from "@/lib/recipes";
 
 export function generateStaticParams() {
   return [{ locale: "en" }, { locale: "he" }];
@@ -17,12 +16,11 @@ export default async function LocaleLayout({
   const { locale: localeParam } = await params;
   const locale = localeParam as Locale;
   const isHebrew = locale === "he";
-  const searchIndex = buildSearchIndex(getAllRecipes());
 
   return (
     <div dir={isHebrew ? "rtl" : "ltr"} lang={locale}>
       <Navbar locale={locale} />
-      <WebMCPProvider recipes={searchIndex} locale={locale} />
+      <WebMCPProvider locale={locale} />
       <main className="max-w-6xl mx-auto px-4 sm:px-6 py-8">
         {children}
       </main>

--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
-import Image from "next/image";
 import { getAllRecipes, type Locale } from "@/lib/recipes";
 import RecipeCard from "@/components/RecipeCard";
+import PictureImage from "@/components/PictureImage";
 
 export async function generateMetadata({
   params,
@@ -22,7 +22,7 @@ export async function generateMetadata({
       description,
       url: `/${locale}`,
       locale: isHebrew ? "he_IL" : "en_US",
-      images: [{ url: "/savta.jpg", width: 400, height: 400 }],
+      images: [{ url: "/savta-og.jpg", width: 1200, height: 1200 }],
     },
   };
 }
@@ -39,7 +39,7 @@ export default async function RecipeGrid({
 
   if (recipes.length === 0) {
     return (
-      <div className="text-center py-20 animate-fade-up">
+      <div className="text-center py-20">
         <p className="text-[var(--color-ink-secondary)]">
           {isHebrew
             ? "אין עדיין מתכונים. הפעל את הפייפליין כדי לעבד סריקות."
@@ -50,7 +50,7 @@ export default async function RecipeGrid({
   }
 
   return (
-    <div className="animate-fade-up">
+    <div>
       {/* Hero — Savta's portrait & dedication */}
       <div className="text-center pt-6 pb-10">
         <div
@@ -60,8 +60,8 @@ export default async function RecipeGrid({
               "0 0 0 3px var(--color-bg), 0 0 0 5px var(--color-border-strong), 0 8px 24px rgba(44, 24, 16, 0.12)",
           }}
         >
-          <Image
-            src="/savta.webp"
+          <PictureImage
+            src="savta.webp"
             alt="Savta"
             fill
             className="object-cover object-top"
@@ -103,8 +103,7 @@ export default async function RecipeGrid({
             illustration={recipe.illustration}
             tags={recipe.tags}
             locale={locale}
-            index={i}
-            priority={i < 4}
+            priority={i < 2}
           />
         ))}
       </div>

--- a/website/app/[locale]/recipe/[slug]/page.tsx
+++ b/website/app/[locale]/recipe/[slug]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
-import Image from "next/image";
 import { getAllRecipes, getRecipeBySlug, type Locale } from "@/lib/recipes";
 import { optimizedImage } from "@/lib/image-utils";
 import ScanViewer from "@/components/ScanViewer";
 import BackButton from "@/components/BackButton";
+import PictureImage from "@/components/PictureImage";
 
 export async function generateMetadata({
   params,
@@ -70,7 +70,7 @@ export default async function RecipeDetail({
   }
 
   return (
-    <article className="animate-fade-up">
+    <article>
       {/* Unified hero — illustration, title, and original scans */}
       <div className="bg-[var(--color-bg-recessed)] -mx-4 sm:-mx-6 px-4 sm:px-6 py-8 mb-10 rounded-xl">
         <div className="max-w-5xl mx-auto">
@@ -81,8 +81,8 @@ export default async function RecipeDetail({
                 className="relative aspect-[4/5] rounded-2xl overflow-hidden"
                 style={{ boxShadow: "var(--shadow-card-hover)" }}
               >
-                <Image
-                  src={`/${optimizedImage(recipe.illustration, 800)}`}
+                <PictureImage
+                  src={optimizedImage(recipe.illustration, 800)}
                   alt={recipe.title[locale]}
                   fill
                   className="object-cover"

--- a/website/app/[locale]/search/page.tsx
+++ b/website/app/[locale]/search/page.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from "react";
-import { getAllRecipes, type Locale } from "@/lib/recipes";
-import { buildSearchIndex } from "@/lib/search";
+import { type Locale } from "@/lib/recipes";
 import SearchResults from "@/components/SearchResults";
 
 export default async function SearchPage({
@@ -10,12 +9,10 @@ export default async function SearchPage({
 }) {
   const { locale: localeParam } = await params;
   const locale = localeParam as Locale;
-  const recipes = getAllRecipes();
-  const searchIndex = buildSearchIndex(recipes);
 
   return (
     <Suspense>
-      <SearchResults recipes={searchIndex} locale={locale} />
+      <SearchResults locale={locale} />
     </Suspense>
   );
 }

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -129,6 +129,14 @@ input, button, textarea, select {
   animation: card-enter 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-up,
+  .animate-fade-in,
+  .animate-card-enter {
+    animation: none !important;
+  }
+}
+
 /* ── Scrollbar ── */
 
 ::-webkit-scrollbar {

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -13,6 +13,7 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   variable: "--font-body",
   display: "swap",
+  preload: false,
 });
 
 export const metadata: Metadata = {
@@ -25,14 +26,14 @@ export const metadata: Metadata = {
   openGraph: {
     siteName: "Savta's Recipes",
     type: "website",
-    images: [{ url: "/savta.jpg", width: 400, height: 400, alt: "Savta" }],
+    images: [{ url: "/savta-og.jpg", width: 1200, height: 1200, alt: "Savta" }],
   },
   twitter: {
     card: "summary_large_image",
   },
   icons: {
     icon: "/icon.svg",
-    apple: "/savta.jpg",
+    apple: "/savta-apple.png",
   },
   other: {
     "mobile-web-app-capable": "yes",

--- a/website/components/Navbar.tsx
+++ b/website/components/Navbar.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
-import { getAllRecipes, type Locale } from "@/lib/recipes";
-import { buildSearchIndex } from "@/lib/search";
+import { type Locale } from "@/lib/recipes";
 import LanguageToggle from "./LanguageToggle";
 import SearchInput from "./SearchInput";
 
@@ -10,8 +9,6 @@ interface NavbarProps {
 
 export default function Navbar({ locale }: NavbarProps) {
   const isHebrew = locale === "he";
-  const recipes = getAllRecipes();
-  const searchIndex = buildSearchIndex(recipes);
 
   return (
     <header
@@ -32,7 +29,7 @@ export default function Navbar({ locale }: NavbarProps) {
         </Link>
 
         <div className="hidden sm:block flex-1 max-w-xs mx-4">
-          <SearchInput recipes={searchIndex} locale={locale} />
+          <SearchInput locale={locale} />
         </div>
 
         <div className="flex items-center gap-1 sm:gap-3">

--- a/website/components/PictureImage.tsx
+++ b/website/components/PictureImage.tsx
@@ -1,0 +1,55 @@
+interface PictureImageProps {
+  /** WebP path relative to public/, e.g. "illustrations/uuid-400w.webp". */
+  src: string;
+  alt: string;
+  sizes?: string;
+  className?: string;
+  /** If true, positions the image absolutely to fill the (position: relative) parent. */
+  fill?: boolean;
+  /** Explicit dimensions (required when fill is false). */
+  width?: number;
+  height?: number;
+  /** Sets loading=eager + fetchpriority=high. */
+  priority?: boolean;
+}
+
+/**
+ * Lightweight <picture> wrapper that serves AVIF with a WebP fallback.
+ * The build step emits matching `-<w>w.avif` and `-<w>w.webp` files for every size.
+ * Falls back gracefully when only the WebP variant exists (e.g. `savta.webp`).
+ */
+export default function PictureImage({
+  src,
+  alt,
+  sizes,
+  className,
+  fill = false,
+  width,
+  height,
+  priority = false,
+}: PictureImageProps) {
+  const avif = src.replace(/\.webp$/i, ".avif");
+  const imgStyle = fill
+    ? { position: "absolute" as const, inset: 0, width: "100%", height: "100%" }
+    : undefined;
+
+  return (
+    <picture>
+      {avif !== src && <source type="image/avif" srcSet={`/${avif}`} sizes={sizes} />}
+      <source type="image/webp" srcSet={`/${src}`} sizes={sizes} />
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={`/${src}`}
+        alt={alt}
+        sizes={sizes}
+        width={fill ? undefined : width}
+        height={fill ? undefined : height}
+        loading={priority ? "eager" : "lazy"}
+        decoding={priority ? "sync" : "async"}
+        fetchPriority={priority ? "high" : "auto"}
+        className={className}
+        style={imgStyle}
+      />
+    </picture>
+  );
+}

--- a/website/components/RecipeCard.tsx
+++ b/website/components/RecipeCard.tsx
@@ -1,7 +1,7 @@
-import Image from "next/image";
 import Link from "next/link";
 import type { Locale } from "@/lib/recipes";
 import { optimizedImage } from "@/lib/image-utils";
+import PictureImage from "./PictureImage";
 
 interface RecipeCardProps {
   slug: string;
@@ -9,7 +9,6 @@ interface RecipeCardProps {
   illustration: string;
   tags?: Array<{ en: string; he: string }>;
   locale: Locale;
-  index?: number;
   priority?: boolean;
 }
 
@@ -19,20 +18,16 @@ export default function RecipeCard({
   illustration,
   tags,
   locale,
-  index = 0,
   priority = false,
 }: RecipeCardProps) {
   return (
     <Link
       href={`/${locale}/recipe/${slug}`}
-      className="group relative aspect-square rounded-xl overflow-hidden animate-card-enter cursor-pointer"
-      style={{
-        animationDelay: `${index * 50}ms`,
-        boxShadow: "var(--shadow-card)",
-      }}
+      className="group relative aspect-square rounded-xl overflow-hidden cursor-pointer"
+      style={{ boxShadow: "var(--shadow-card)" }}
     >
-      <Image
-        src={`/${optimizedImage(illustration, 400)}`}
+      <PictureImage
+        src={optimizedImage(illustration, 400)}
         alt={title[locale]}
         fill
         className="object-cover transition-transform duration-500 ease-out [@media(hover:hover)]:group-hover:scale-[1.04]"

--- a/website/components/SearchInput.tsx
+++ b/website/components/SearchInput.tsx
@@ -1,21 +1,22 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type { SearchableRecipe } from "@/lib/search";
-import { createFuse } from "@/lib/search";
+import { loadSearchIndex } from "@/lib/search-client";
 import type { Locale } from "@/lib/recipes";
 import { optimizedImage } from "@/lib/image-utils";
+import PictureImage from "./PictureImage";
+
+type Fuse<T> = import("fuse.js").default<T>;
 
 interface SearchInputProps {
-  recipes: SearchableRecipe[];
   locale: Locale;
   variant?: "navbar" | "page";
 }
 
-export default function SearchInput({ recipes, locale, variant = "navbar" }: SearchInputProps) {
+export default function SearchInput({ locale, variant = "navbar" }: SearchInputProps) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchableRecipe[]>([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -23,24 +24,31 @@ export default function SearchInput({ recipes, locale, variant = "navbar" }: Sea
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
-  const fuseRef = useRef(createFuse(recipes));
+  const fuseRef = useRef<Fuse<SearchableRecipe> | null>(null);
   const router = useRouter();
 
-  // Total selectable items: results + "All results" link
   const totalItems = results.length + (results.length > 0 ? 1 : 0);
 
-  const search = useCallback((q: string) => {
+  const ensureIndex = useCallback(async () => {
+    if (fuseRef.current) return fuseRef.current;
+    const { fuse } = await loadSearchIndex();
+    fuseRef.current = fuse;
+    return fuse;
+  }, []);
+
+  const search = useCallback(async (q: string) => {
     if (q.trim().length === 0) {
       setResults([]);
       setIsOpen(false);
       setActiveIndex(-1);
       return;
     }
-    const found = fuseRef.current.search(q).slice(0, 5).map((r) => r.item);
+    const fuse = await ensureIndex();
+    const found = fuse.search(q).slice(0, 5).map((r) => r.item);
     setResults(found);
     setIsOpen(found.length > 0);
     setActiveIndex(-1);
-  }, []);
+  }, [ensureIndex]);
 
   useEffect(() => {
     const timer = setTimeout(() => search(query), 150);
@@ -74,12 +82,14 @@ export default function SearchInput({ recipes, locale, variant = "navbar" }: Sea
     return () => document.removeEventListener("pointerdown", handleOutside);
   }, []);
 
-  // Scroll active item into view
+  // Scroll active item into view (rAF-scheduled so we don't force layout synchronously on every keystroke)
   useEffect(() => {
-    if (activeIndex >= 0 && itemRefs.current[activeIndex]) {
-      itemRefs.current[activeIndex]?.scrollIntoView({ block: "nearest" });
-    }
-  }, [activeIndex]);
+    if (!isOpen || activeIndex < 0) return;
+    const el = itemRefs.current[activeIndex];
+    if (!el) return;
+    const id = requestAnimationFrame(() => el.scrollIntoView({ block: "nearest" }));
+    return () => cancelAnimationFrame(id);
+  }, [activeIndex, isOpen]);
 
   function handleInputKeyDown(e: React.KeyboardEvent) {
     if (e.key === "ArrowDown") {
@@ -98,7 +108,6 @@ export default function SearchInput({ recipes, locale, variant = "navbar" }: Sea
         setIsOpen(false);
         setQuery("");
       } else if (activeIndex === results.length) {
-        // "All results" link
         router.push(`/${locale}/search${query ? `?q=${encodeURIComponent(query)}` : ""}`);
         setIsOpen(false);
       } else if (query.trim()) {
@@ -128,7 +137,10 @@ export default function SearchInput({ recipes, locale, variant = "navbar" }: Sea
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          onFocus={() => results.length > 0 && setIsOpen(true)}
+          onFocus={() => {
+            void ensureIndex();
+            if (results.length > 0) setIsOpen(true);
+          }}
           onKeyDown={handleInputKeyDown}
           placeholder={locale === "he" ? "חיפוש מתכונים..." : "Search recipes..."}
           dir={locale === "he" ? "rtl" : "ltr"}
@@ -169,8 +181,8 @@ export default function SearchInput({ recipes, locale, variant = "navbar" }: Sea
               }`}
             >
               <div className="relative w-10 h-10 rounded-lg overflow-hidden flex-shrink-0">
-                <Image
-                  src={`/${optimizedImage(r.illustration, 400)}`}
+                <PictureImage
+                  src={optimizedImage(r.illustration, 400)}
                   alt={locale === "he" ? r.titleHe : r.titleEn}
                   fill
                   className="object-cover"
@@ -182,7 +194,7 @@ export default function SearchInput({ recipes, locale, variant = "navbar" }: Sea
                   {locale === "he" ? r.titleHe : r.titleEn}
                 </p>
                 <p className="text-xs text-[var(--color-ink-tertiary)] truncate">
-                  {(locale === "he" ? r.tagsHe : r.tagsEn).slice(0, 3).join(" \u00b7 ")}
+                  {(locale === "he" ? r.tagsHe : r.tagsEn).slice(0, 3).join(" · ")}
                 </p>
               </div>
             </Link>

--- a/website/components/SearchResults.tsx
+++ b/website/components/SearchResults.tsx
@@ -1,37 +1,53 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
-import Image from "next/image";
 import Link from "next/link";
 import type { SearchableRecipe } from "@/lib/search";
-import { createFuse } from "@/lib/search";
+import { loadSearchIndex } from "@/lib/search-client";
 import { optimizedImage } from "@/lib/image-utils";
+import PictureImage from "./PictureImage";
+
+type Fuse<T> = import("fuse.js").default<T>;
 
 interface SearchResultsProps {
-  recipes: SearchableRecipe[];
   locale: "en" | "he";
 }
 
-export default function SearchResults({ recipes, locale }: SearchResultsProps) {
+export default function SearchResults({ locale }: SearchResultsProps) {
   const searchParams = useSearchParams();
   const initialQuery = searchParams.get("q") || "";
   const [query, setQuery] = useState(initialQuery);
-  const fuse = useMemo(() => createFuse(recipes), [recipes]);
+  const [recipes, setRecipes] = useState<SearchableRecipe[] | null>(null);
+  const [fuse, setFuse] = useState<Fuse<SearchableRecipe> | null>(null);
   const isHebrew = locale === "he";
 
-  const results = useMemo(() => {
-    if (query.trim().length === 0) return recipes;
-    return fuse.search(query).map((r) => r.item);
-  }, [query, fuse, recipes]);
+  useEffect(() => {
+    let cancelled = false;
+    loadSearchIndex().then((res) => {
+      if (cancelled) return;
+      setRecipes(res.recipes);
+      setFuse(res.fuse);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     const q = searchParams.get("q");
-    if (q) setQuery(q);
+    if (q !== null) setQuery(q);
   }, [searchParams]);
 
+  const results =
+    recipes === null
+      ? []
+      : query.trim().length === 0 || fuse === null
+        ? recipes
+        : fuse.search(query).map((r) => r.item);
+
   return (
-    <div className="py-8 animate-fade-up">
+    <div className="py-8">
       <h1 className="font-semibold text-3xl text-[var(--color-ink)] text-center mb-8">
         {isHebrew ? "חיפוש מתכונים" : "Search Recipes"}
       </h1>
@@ -60,24 +76,25 @@ export default function SearchResults({ recipes, locale }: SearchResultsProps) {
         </div>
       </div>
 
-      {results.length === 0 ? (
+      {recipes === null ? (
+        <p className="text-center text-[var(--color-ink-tertiary)]">
+          {isHebrew ? "טוען..." : "Loading..."}
+        </p>
+      ) : results.length === 0 ? (
         <p className="text-center text-[var(--color-ink-tertiary)]">
           {isHebrew ? "לא נמצאו תוצאות" : "No results found"}
         </p>
       ) : (
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-5">
-          {results.map((r, i) => (
+          {results.map((r) => (
             <Link
               key={r.slug}
               href={`/${locale}/recipe/${r.slug}`}
-              className="group relative aspect-square rounded-xl overflow-hidden animate-card-enter cursor-pointer"
-              style={{
-                animationDelay: `${i * 50}ms`,
-                boxShadow: "var(--shadow-card)",
-              }}
+              className="group relative aspect-square rounded-xl overflow-hidden cursor-pointer"
+              style={{ boxShadow: "var(--shadow-card)" }}
             >
-              <Image
-                src={`/${optimizedImage(r.illustration, 400)}`}
+              <PictureImage
+                src={optimizedImage(r.illustration, 400)}
                 alt={locale === "he" ? r.titleHe : r.titleEn}
                 fill
                 className="object-cover transition-transform duration-500 ease-out [@media(hover:hover)]:group-hover:scale-[1.04]"
@@ -95,7 +112,7 @@ export default function SearchResults({ recipes, locale }: SearchResultsProps) {
                   {locale === "he" ? r.titleHe : r.titleEn}
                 </h2>
                 <p className="text-[10px] sm:text-xs text-[var(--color-ink-tertiary)] truncate mt-0.5">
-                  {(locale === "he" ? r.tagsHe : r.tagsEn).slice(0, 3).join(" \u00b7 ")}
+                  {(locale === "he" ? r.tagsHe : r.tagsEn).slice(0, 3).join(" · ")}
                 </p>
               </div>
             </Link>

--- a/website/components/WebMCPProvider.tsx
+++ b/website/components/WebMCPProvider.tsx
@@ -2,15 +2,14 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { createFuse, type SearchableRecipe } from "@/lib/search";
+import { loadSearchIndex } from "@/lib/search-client";
 import type { Locale } from "@/lib/recipes";
 
 interface WebMCPProviderProps {
-  recipes: SearchableRecipe[];
   locale: Locale;
 }
 
-export default function WebMCPProvider({ recipes, locale }: WebMCPProviderProps) {
+export default function WebMCPProvider({ locale }: WebMCPProviderProps) {
   const router = useRouter();
 
   useEffect(() => {
@@ -22,97 +21,114 @@ export default function WebMCPProvider({ recipes, locale }: WebMCPProviderProps)
 
     if (!nav.modelContext?.provideContext) return;
 
-    const fuse = createFuse(recipes);
+    const idle = (cb: () => void) => {
+      const w = window as Window & {
+        requestIdleCallback?: (cb: () => void) => number;
+      };
+      if (typeof w.requestIdleCallback === "function") w.requestIdleCallback(cb);
+      else setTimeout(cb, 500);
+    };
 
-    nav.modelContext.provideContext({
-      tools: [
-        {
-          name: "search_recipes",
-          description:
-            "Search Savta's recipe collection by name, ingredient, or tag. Returns matching recipes with slugs and URLs.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              query: {
-                type: "string",
-                description: "Search query — recipe name, ingredient, or tag",
+    let cancelled = false;
+    idle(async () => {
+      if (cancelled) return;
+      const { fuse, recipes } = await loadSearchIndex();
+      if (cancelled) return;
+
+      nav.modelContext!.provideContext({
+        tools: [
+          {
+            name: "search_recipes",
+            description:
+              "Search Savta's recipe collection by name, ingredient, or tag. Returns matching recipes with slugs and URLs.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                query: {
+                  type: "string",
+                  description: "Search query — recipe name, ingredient, or tag",
+                },
               },
+              required: ["query"],
             },
-            required: ["query"],
-          },
-          execute: (params: { query: string }) => {
-            const results = fuse
-              .search(params.query)
-              .slice(0, 10)
-              .map((r) => ({
-                slug: r.item.slug,
-                titleEn: r.item.titleEn,
-                titleHe: r.item.titleHe,
-                tags: locale === "he" ? r.item.tagsHe : r.item.tagsEn,
-                url: `/${locale}/recipe/${r.item.slug}`,
-              }));
-            return { results };
-          },
-        },
-        {
-          name: "list_all_recipes",
-          description:
-            "List every recipe in Savta's collection with names, tags, and page URLs.",
-          inputSchema: {
-            type: "object",
-            properties: {},
-          },
-          execute: () => ({
-            recipes: recipes.map((r) => ({
-              slug: r.slug,
-              titleEn: r.titleEn,
-              titleHe: r.titleHe,
-              tags: locale === "he" ? r.tagsHe : r.tagsEn,
-              url: `/${locale}/recipe/${r.slug}`,
-            })),
-          }),
-        },
-        {
-          name: "navigate_to_recipe",
-          description: "Navigate the browser to a specific recipe page.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              slug: {
-                type: "string",
-                description: "Recipe slug from search_recipes or list_all_recipes",
-              },
-            },
-            required: ["slug"],
-          },
-          execute: (params: { slug: string }) => {
-            const url = `/${locale}/recipe/${params.slug}`;
-            router.push(url);
-            return { navigating: true, url };
-          },
-        },
-        {
-          name: "navigate_to_search",
-          description:
-            "Navigate to the recipe search page, optionally pre-filled with a query.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              query: {
-                type: "string",
-                description: "Optional search query to pre-fill",
-              },
+            execute: (params: { query: string }) => {
+              const results = fuse
+                .search(params.query)
+                .slice(0, 10)
+                .map((r) => ({
+                  slug: r.item.slug,
+                  titleEn: r.item.titleEn,
+                  titleHe: r.item.titleHe,
+                  tags: locale === "he" ? r.item.tagsHe : r.item.tagsEn,
+                  url: `/${locale}/recipe/${r.item.slug}`,
+                }));
+              return { results };
             },
           },
-          execute: (params: { query?: string }) => {
-            const url = `/${locale}/search${params.query ? `?q=${encodeURIComponent(params.query)}` : ""}`;
-            router.push(url);
-            return { navigating: true, url };
+          {
+            name: "list_all_recipes",
+            description:
+              "List every recipe in Savta's collection with names, tags, and page URLs.",
+            inputSchema: {
+              type: "object",
+              properties: {},
+            },
+            execute: () => ({
+              recipes: recipes.map((r) => ({
+                slug: r.slug,
+                titleEn: r.titleEn,
+                titleHe: r.titleHe,
+                tags: locale === "he" ? r.tagsHe : r.tagsEn,
+                url: `/${locale}/recipe/${r.slug}`,
+              })),
+            }),
           },
-        },
-      ],
+          {
+            name: "navigate_to_recipe",
+            description: "Navigate the browser to a specific recipe page.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                slug: {
+                  type: "string",
+                  description: "Recipe slug from search_recipes or list_all_recipes",
+                },
+              },
+              required: ["slug"],
+            },
+            execute: (params: { slug: string }) => {
+              const url = `/${locale}/recipe/${params.slug}`;
+              router.push(url);
+              return { navigating: true, url };
+            },
+          },
+          {
+            name: "navigate_to_search",
+            description:
+              "Navigate to the recipe search page, optionally pre-filled with a query.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                query: {
+                  type: "string",
+                  description: "Optional search query to pre-fill",
+                },
+              },
+            },
+            execute: (params: { query?: string }) => {
+              const url = `/${locale}/search${params.query ? `?q=${encodeURIComponent(params.query)}` : ""}`;
+              router.push(url);
+              return { navigating: true, url };
+            },
+          },
+        ],
+      });
     });
-  }, [recipes, locale, router]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [locale, router]);
 
   return null;
 }

--- a/website/lib/search-client.ts
+++ b/website/lib/search-client.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import type { SearchableRecipe } from "./search";
+
+type Fuse<T> = import("fuse.js").default<T>;
+
+interface LoadedIndex {
+  fuse: Fuse<SearchableRecipe>;
+  recipes: SearchableRecipe[];
+}
+
+let cache: Promise<LoadedIndex> | null = null;
+
+export function loadSearchIndex(): Promise<LoadedIndex> {
+  if (cache) return cache;
+  cache = (async () => {
+    const [{ default: FuseCtor }, res] = await Promise.all([
+      import("fuse.js"),
+      fetch("/search-index.json", { credentials: "omit" }),
+    ]);
+    const recipes = (await res.json()) as SearchableRecipe[];
+    const fuse = new FuseCtor(recipes, {
+      keys: [
+        { name: "titleEn", weight: 3 },
+        { name: "titleHe", weight: 3 },
+        { name: "ingredients", weight: 2 },
+        { name: "tagsEn", weight: 1.5 },
+        { name: "tagsHe", weight: 1.5 },
+        { name: "description", weight: 1 },
+      ],
+      threshold: 0.4,
+      includeScore: true,
+    });
+    return { fuse, recipes };
+  })();
+  return cache;
+}

--- a/website/lib/search.ts
+++ b/website/lib/search.ts
@@ -1,46 +1,25 @@
-import Fuse from "fuse.js";
-import type { Recipe, Locale } from "./recipes";
+import type { Recipe } from "./recipes";
 
 export interface SearchableRecipe {
   slug: string;
-  title: string;
+  titleEn: string;
+  titleHe: string;
   description: string;
   ingredients: string;
-  tags: string;
   tagsEn: string[];
   tagsHe: string[];
   illustration: string;
-  titleHe: string;
-  titleEn: string;
 }
 
-export function buildSearchIndex(
-  recipes: Recipe[]
-): SearchableRecipe[] {
+export function buildSearchIndex(recipes: Recipe[]): SearchableRecipe[] {
   return recipes.map((r) => ({
     slug: r.slug,
-    title: r.title.en,
+    titleEn: r.title.en,
+    titleHe: r.title.he,
     description: r.description.en,
     ingredients: r.ingredients.map((i) => `${i.en} ${i.he}`).join(" "),
-    tags: r.tags.map((t) => `${t.en} ${t.he}`).join(" "),
     tagsEn: r.tags.map((t) => t.en),
     tagsHe: r.tags.map((t) => t.he),
     illustration: r.illustration,
-    titleHe: r.title.he,
-    titleEn: r.title.en,
   }));
-}
-
-export function createFuse(items: SearchableRecipe[]): Fuse<SearchableRecipe> {
-  return new Fuse(items, {
-    keys: [
-      { name: "title", weight: 3 },
-      { name: "titleHe", weight: 3 },
-      { name: "ingredients", weight: 2 },
-      { name: "tags", weight: 1.5 },
-      { name: "description", weight: 1 },
-    ],
-    threshold: 0.4,
-    includeScore: true,
-  });
 }

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "prebuild": "node --experimental-strip-types --no-warnings scripts/optimize-images.ts",
+    "prebuild": "node --experimental-strip-types --no-warnings scripts/optimize-images.ts && node --experimental-strip-types --no-warnings scripts/build-search-index.ts",
     "build": "next build",
     "start": "next start",
     "postbuild": "node --experimental-strip-types --no-warnings scripts/generate-markdown.ts"

--- a/website/scripts/build-search-index.ts
+++ b/website/scripts/build-search-index.ts
@@ -1,0 +1,53 @@
+/**
+ * Emits public/search-index.json with the minimal data the client search needs.
+ * Keeps the RSC Flight payload inlined in HTML out of the critical request — the
+ * index is fetched lazily on first search interaction instead.
+ */
+
+import { readFileSync, readdirSync, writeFileSync, existsSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+interface Recipe {
+  slug: string;
+  title: { en: string; he: string };
+  description: { en: string; he: string };
+  ingredients: Array<{ en: string; he: string }>;
+  tags: Array<{ en: string; he: string }>;
+  illustration: string;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const RECIPES_DIR = resolve(__dirname, "../../data/recipes");
+const OUT = resolve(__dirname, "../public/search-index.json");
+
+if (!existsSync(RECIPES_DIR)) {
+  console.log("No recipes directory found; skipping search-index.json");
+  process.exit(0);
+}
+
+const recipes = readdirSync(RECIPES_DIR)
+  .filter((f) => f.endsWith(".json") && !f.startsWith(".") && f !== "index.json")
+  .map((f) => JSON.parse(readFileSync(resolve(RECIPES_DIR, f), "utf-8")) as Recipe);
+
+// Deduplicate slugs to match lib/recipes.ts's collision handling.
+const slugCounts = new Map<string, number>();
+for (const r of recipes) {
+  const count = (slugCounts.get(r.slug) ?? 0) + 1;
+  slugCounts.set(r.slug, count);
+  if (count > 1) r.slug = `${r.slug}-${count}`;
+}
+
+const index = recipes.map((r) => ({
+  slug: r.slug,
+  titleEn: r.title.en,
+  titleHe: r.title.he,
+  description: r.description.en,
+  ingredients: r.ingredients.map((i) => `${i.en} ${i.he}`).join(" "),
+  tagsEn: r.tags.map((t) => t.en),
+  tagsHe: r.tags.map((t) => t.he),
+  illustration: r.illustration,
+}));
+
+writeFileSync(OUT, JSON.stringify(index));
+console.log(`Wrote ${index.length} recipes to public/search-index.json`);

--- a/website/scripts/optimize-images.ts
+++ b/website/scripts/optimize-images.ts
@@ -27,7 +27,7 @@ interface Variant {
   suffix: string;
   width: number;
   quality: number;
-  format?: "webp" | "png";
+  format?: "webp" | "png" | "jpeg" | "avif";
 }
 
 async function optimizeFile(
@@ -40,7 +40,8 @@ async function optimizeFile(
 
   for (const variant of variants) {
     const format = variant.format ?? "webp";
-    const outPath = resolve(outputDir, `${nameBase}${variant.suffix}.${format}`);
+    const ext = format === "jpeg" ? "jpg" : format;
+    const outPath = resolve(outputDir, `${nameBase}${variant.suffix}.${ext}`);
 
     if (existsSync(outPath) && !force) {
       continue;
@@ -49,6 +50,10 @@ async function optimizeFile(
     const pipeline = sharp(inputPath).resize(variant.width, undefined, { withoutEnlargement: true });
     if (format === "png") {
       await pipeline.png({ quality: variant.quality, compressionLevel: 8 }).toFile(outPath);
+    } else if (format === "jpeg") {
+      await pipeline.jpeg({ quality: variant.quality, mozjpeg: true }).toFile(outPath);
+    } else if (format === "avif") {
+      await pipeline.avif({ quality: variant.quality, effort: 4 }).toFile(outPath);
     } else {
       await pipeline.webp({ quality: variant.quality }).toFile(outPath);
     }
@@ -75,7 +80,7 @@ async function main() {
   // Illustrations
   if (existsSync(ILLUSTRATIONS_DIR)) {
     const files = readdirSync(ILLUSTRATIONS_DIR).filter(
-      (f) => /\.(jpe?g|png|webp)$/i.test(f) && !/-\d+w\.webp$/.test(f)
+      (f) => /\.(jpe?g|png|webp)$/i.test(f) && !/-(\d+w|og)\.(webp|avif|png)$/.test(f)
     );
 
     for (const file of files) {
@@ -87,6 +92,8 @@ async function main() {
         variants: [
           { suffix: "-400w", width: 400, quality: 80 },
           { suffix: "-800w", width: 800, quality: 80 },
+          { suffix: "-400w", width: 400, quality: 55, format: "avif" },
+          { suffix: "-800w", width: 800, quality: 55, format: "avif" },
           { suffix: "-og", width: 1200, quality: 90, format: "png" },
         ],
         label: `illus/${file}`,
@@ -117,8 +124,16 @@ async function main() {
 
 
   // Static public assets
-  const staticAssets = [
-    { file: 'savta.jpg', variants: [{ suffix: '', width: 300, quality: 85 }] },
+  const staticAssets: Array<{ file: string; variants: Variant[] }> = [
+    {
+      file: "savta.jpg",
+      variants: [
+        { suffix: "", width: 300, quality: 85, format: "webp" },
+        { suffix: "", width: 300, quality: 55, format: "avif" },
+        { suffix: "-og", width: 1200, quality: 82, format: "jpeg" },
+        { suffix: "-apple", width: 180, quality: 90, format: "png" },
+      ],
+    },
   ];
 
   for (const { file, variants } of staticAssets) {
@@ -129,7 +144,7 @@ async function main() {
         input: inputPath,
         outputDir: PUBLIC_DIR,
         nameBase: name,
-        variants: variants.map((v) => ({ ...v, format: 'webp' as const })),
+        variants,
         label: `public/${file}`,
       });
     }


### PR DESCRIPTION
## Summary

Addresses PageSpeed Insights issues on `recipes.atlow.co.il/he`: TBT 350 ms, 3.1 s main-thread work, the 751 KiB image-savings line item, the LCP preload / `fetchpriority=high` flag, the flagged forced reflow, and the `/he → CSS → font` critical chain.

Root causes that were fixed:
- **Recipe search index was inlined into every page's HTML** — `SearchInput` (via `Navbar`) and `WebMCPProvider` both took the full index as props, so Next serialized it twice into the RSC Flight payload on every page load.
- **LCP was blocked by CSS `opacity:0` animations** — `animate-fade-up` wrapped the whole page view and `animate-card-enter` used `animationDelay: index * 50ms` (the last card faded in at 7.75 s).
- **Large OG asset** — `/savta.jpg` (389 KB) was being used for OG + Apple-touch metadata.
- **Forced reflow** — `SearchInput` called `scrollIntoView` from a `useEffect` on every `activeIndex` change, including when the dropdown was closed.
- **3 woff2 fonts preloaded** — JetBrains Mono was on the critical chain despite `display: swap`.
- **Image format** — WebP only; no AVIF.
- **Pre-existing bug** — `optimize-images.ts` filter allowed `-og.png` back in as a source, creating a runaway chain of `-og-og-og-...` files on every build.

### Changes

- Lazy-load the search index: prebuild now emits `public/search-index.json`; clients fetch it and dynamic-`import('fuse.js')` on first interaction. Fuse moves to a lazy chunk (~17.8 KB).
- Drop `animate-fade-up`/`animate-card-enter` from LCP subtrees; add `prefers-reduced-motion` guard to the surviving keyframes.
- New `PictureImage` wrapper (`<picture>` + `<source type=\"image/avif\">` + WebP fallback); prebuild emits matching `-400w.avif` and `-800w.avif` plus `savta.avif`.
- rAF-schedule + `isOpen`-gate the `scrollIntoView` effect.
- `preload: false` for JetBrains Mono.
- New `savta-og.jpg` (97 KB, 1200×1200, mozjpeg q82) and `savta-apple.png` (18 KB, 180×180); metadata points at them.
- Fix the `optimize-images` source filter to exclude `-og.{webp,avif,png}` and `-<digits>w.{webp,avif,png}`.

### Measured impact (local build)

| | before | after |
|---|---|---|
| `/he.html` gzipped | 126 KB | **35.5 KB** |
| First Load JS shared | ~300 KB+ | **101 KB** |
| Font preloads | 3 | **2** |
| Image preloads | 4 recipe cards + savta | just savta |
| AVIF variants | 0 | 157 × 2 + savta |
| OG image | 389 KB (jpg) | **97 KB** (jpg) |
| Apple-touch icon | 389 KB (jpg) | **18 KB** (png) |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds (324 static pages)
- [x] `/he.html` serialized RSC payload no longer contains the search index
- [x] Hero `<img src=\"/savta.webp\">` has `loading=\"eager\"` + `fetchPriority=\"high\"`; first 2 cards same; non-priority cards `loading=\"lazy\"`
- [x] 157 `<source type=\"image/avif\">` tags emitted on the home page
- [x] Spot-check: 400w.webp 27 KB → 400w.avif 22 KB; 800w.webp 109 KB → 800w.avif 86 KB
- [x] `public/search-index.json` valid JSON with 156 recipes
- [x] Fuse.js lives in a lazy chunk (not loaded on initial navigation)
- [x] Local static serve confirms `/savta.avif`, `/savta-og.jpg`, `/savta-apple.png`, `/search-index.json` all 200
- [ ] Post-deploy Lighthouse run on `recipes.atlow.co.il/he` — verify TBT, LCP, main-thread work, and critical-chain improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)