### PR TITLE
perf(website): cut mobile LCP with preloads, content-visibility, cheaper frosted glass

### DIFF
--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -49,8 +49,26 @@ export default async function RecipeGrid({
     );
   }
 
+  const lcpCandidates = recipes.slice(0, 4);
+
   return (
     <div>
+      {/* Preload the first two recipe card AVIFs so the preload scanner kicks off
+          the LCP image fetch before parsing the ~150-card body. */}
+      {lcpCandidates.map((recipe) => {
+        const avif = recipe.illustration.replace(/\.webp$/i, "-400w.avif");
+        return (
+          <link
+            key={recipe.id}
+            rel="preload"
+            as="image"
+            href={`/${avif}`}
+            type="image/avif"
+            fetchPriority="high"
+          />
+        );
+      })}
+
       {/* Hero — Savta's portrait & dedication */}
       <div className="text-center pt-6 pb-10">
         <div
@@ -103,7 +121,7 @@ export default async function RecipeGrid({
             illustration={recipe.illustration}
             tags={recipe.tags}
             locale={locale}
-            priority={i < 2}
+            priority={i < 4}
           />
         ))}
       </div>

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -137,6 +137,22 @@ input, button, textarea, select {
   }
 }
 
+/* Frosted-glass band on recipe cards. backdrop-filter is expensive to composite
+   on mobile GPUs — hundreds of blurred surfaces blow the paint budget — so we
+   only apply it on hover-capable devices. The slightly more opaque solid color
+   keeps the card title readable on mobile without the blur cost. */
+.frosted-glass {
+  background-color: rgba(250, 247, 242, 0.9);
+}
+
+@media (hover: hover) {
+  .frosted-glass {
+    background-color: rgba(250, 247, 242, 0.82);
+    backdrop-filter: blur(16px) saturate(1.2);
+    -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  }
+}
+
 /* ── Scrollbar ── */
 
 ::-webkit-scrollbar {

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -56,7 +56,7 @@ export default function RootLayout({
     >
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="preload" href="/savta.webp" as="image" type="image/webp" />
+        <link rel="preload" href="/savta.avif" as="image" type="image/avif" />
       </head>
       <body className="min-h-screen antialiased">
         <MobileTapFix />

--- a/website/components/RecipeCard.tsx
+++ b/website/components/RecipeCard.tsx
@@ -24,7 +24,15 @@ export default function RecipeCard({
     <Link
       href={`/${locale}/recipe/${slug}`}
       className="group relative aspect-square rounded-xl overflow-hidden cursor-pointer"
-      style={{ boxShadow: "var(--shadow-card)" }}
+      style={
+        priority
+          ? { boxShadow: "var(--shadow-card)" }
+          : {
+              boxShadow: "var(--shadow-card)",
+              contentVisibility: "auto",
+              containIntrinsicSize: "200px 200px",
+            }
+      }
     >
       <PictureImage
         src={optimizedImage(illustration, 400)}
@@ -36,14 +44,7 @@ export default function RecipeCard({
       />
 
       {/* Frosted glass title band */}
-      <div
-        className="absolute inset-x-0 bottom-0 px-3 py-2.5 sm:px-4 sm:py-3"
-        style={{
-          backgroundColor: "rgba(250, 247, 242, 0.82)",
-          backdropFilter: "blur(16px) saturate(1.2)",
-          WebkitBackdropFilter: "blur(16px) saturate(1.2)",
-        }}
-      >
+      <div className="frosted-glass absolute inset-x-0 bottom-0 px-3 py-2.5 sm:px-4 sm:py-3">
         <h2 className="font-semibold text-sm sm:text-base text-[var(--color-ink)] truncate leading-tight">
           {title[locale]}
         </h2>

--- a/website/components/SearchResults.tsx
+++ b/website/components/SearchResults.tsx
@@ -100,14 +100,7 @@ export default function SearchResults({ locale }: SearchResultsProps) {
                 className="object-cover transition-transform duration-500 ease-out [@media(hover:hover)]:group-hover:scale-[1.04]"
                 sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
               />
-              <div
-                className="absolute inset-x-0 bottom-0 px-3 py-2.5 sm:px-4 sm:py-3"
-                style={{
-                  backgroundColor: "rgba(250, 247, 242, 0.82)",
-                  backdropFilter: "blur(16px) saturate(1.2)",
-                  WebkitBackdropFilter: "blur(16px) saturate(1.2)",
-                }}
-              >
+              <div className="frosted-glass absolute inset-x-0 bottom-0 px-3 py-2.5 sm:px-4 sm:py-3">
                 <h2 className="font-semibold text-sm sm:text-base text-[var(--color-ink)] truncate leading-tight">
                   {locale === "he" ? r.titleHe : r.titleEn}
                 </h2>


### PR DESCRIPTION
Follow-up to #95 targeting the mobile Lighthouse numbers (4.6 s LCP, 4.1 s Speed Index, 240 ms TBT, 393 KiB image-delivery savings).

## Changes

### LCP image discovery
- Emit `<link rel=preload as=image type="image/avif" fetchpriority="high">` for the first **4** recipe-card illustrations in `[locale]/page.tsx`. React 19 hoists these into `<head>`, so the preload scanner can start the LCP image fetch as soon as the HTML arrives instead of waiting for the ~567 KiB body to parse.
- Bump `priority={i < 4}` on those same four cards so the `<img>` tags match (`loading="eager"` + `fetchpriority="high"`).
- Change the root-layout hero preload from `/savta.webp` to `/savta.avif` (plus `type="image/avif"`). The `<picture>` already prefers AVIF; the webp preload was a double-download on AVIF-capable browsers.

### Speed Index / paint cost
- Add `content-visibility: auto` + `contain-intrinsic-size: 200px 200px` to non-priority `RecipeCard`s. The 150+ off-screen cards skip layout and paint until scrolled near, cutting both Speed Index and main-thread time on mobile.
- Replace the per-card inline `backdrop-filter: blur(16px) saturate(1.2)` with a `.frosted-glass` class gated behind `@media (hover: hover)`. Mobile GPUs pay a big rasterize-and-blur cost for hundreds of translucent surfaces; touch devices now fall back to a slightly more opaque solid color that keeps the title band readable without the blur. Same class reused in `SearchResults`.

## Verification

- `npm run build` succeeds; First Load JS shared still 101 KB
- `/he.html` gzipped: 34.9 KB (was 35.5 KB — the removed inline styles help)
- 4 `<link rel=preload as=image type="image/avif" fetchpriority="high">` tags present in `<head>`
- Hero preload now points at `/savta.avif`
- 302 `content-visibility:auto` inline styles on below-fold cards
- `backdrop-filter` no longer appears in rendered HTML; `.frosted-glass` class appears 312 times (156 cards + 156 search results)

Post-deploy mobile Lighthouse will confirm the LCP / Speed Index drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)