### PR TITLE
fix(web): 302 at edge instead of client-side redirect from root

### DIFF
--- a/infra/cloudformation.yaml
+++ b/infra/cloudformation.yaml
@@ -81,11 +81,37 @@ Resources:
         function handler(event) {
           var request = event.request;
           var uri = request.uri;
-          var accept = request.headers['accept'] ? request.headers['accept'].value : '';
+          var headers = request.headers;
+          var accept = headers['accept'] ? headers['accept'].value : '';
           var wantsMarkdown = accept.indexOf('text/markdown') !== -1;
           if (uri === '/') {
-            if (wantsMarkdown) request.uri = '/index.md';
-            return request;
+            if (wantsMarkdown) {
+              request.uri = '/index.md';
+              return request;
+            }
+            // 302 to a locale so agents/crawlers see a real page immediately
+            // rather than a client-side redirect that destroys the JS execution
+            // context mid-probe. Prefer cookie > Accept-Language > 'en'.
+            var locale = 'en';
+            var cookie = headers['cookie'] ? headers['cookie'].value : '';
+            var m = cookie.match(/(?:^|;\s*)locale=(he|en)/);
+            if (m) {
+              locale = m[1];
+            } else {
+              var lang = headers['accept-language']
+                ? headers['accept-language'].value.toLowerCase()
+                : '';
+              if (/\b(he|iw)\b/.test(lang)) locale = 'he';
+            }
+            return {
+              statusCode: 302,
+              statusDescription: 'Found',
+              headers: {
+                'location': { value: '/' + locale },
+                'cache-control': { value: 'no-store' },
+                'vary': { value: 'cookie, accept-language' }
+              }
+            };
           }
           var ext = wantsMarkdown ? '.md' : '.html';
           if (uri.endsWith('/')) {

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,20 +1,9 @@
-"use client";
-
-import { useEffect } from "react";
-
 export default function HomePage() {
-  useEffect(() => {
-    const saved = localStorage.getItem("locale");
-    if (saved === "he" || saved === "en") {
-      window.location.replace(`/${saved}`);
-      return;
-    }
-
-    const browserLang = navigator.language || "";
-    const locale = browserLang.startsWith("he") ? "he" : "en";
-    window.location.replace(`/${locale}`);
-  }, []);
-
+  // `/` is normally 302-redirected to `/<locale>` by the CloudFront function
+  // (see infra/cloudformation.yaml → UrlRewriteFunction). This page only
+  // renders if the edge redirect doesn't fire — so it must not trigger any
+  // client-side navigation (that destroyed the JS execution context the
+  // WebMCP checker probes). noscript meta-refresh is the only safe fallback.
   return (
     <noscript>
       <meta httpEquiv="refresh" content="0;url=/en" />

--- a/website/components/LanguageToggle.tsx
+++ b/website/components/LanguageToggle.tsx
@@ -15,6 +15,13 @@ export default function LanguageToggle({ currentLocale }: LanguageToggleProps) {
     return pathname.replace(`/${currentLocale}`, `/${locale}`);
   }
 
+  function rememberLocale(locale: Locale) {
+    localStorage.setItem("locale", locale);
+    // Cookie is read by the CloudFront edge function to 302 `/` to the
+    // right locale for bookmarked bare-domain visits.
+    document.cookie = `locale=${locale}; path=/; max-age=31536000; SameSite=Lax`;
+  }
+
   return (
     <div
       dir="ltr"
@@ -22,7 +29,7 @@ export default function LanguageToggle({ currentLocale }: LanguageToggleProps) {
     >
       <Link
         href={getPath("en")}
-        onClick={() => localStorage.setItem("locale", "en")}
+        onClick={() => rememberLocale("en")}
         className={`px-3.5 py-1.5 sm:px-3 sm:py-1 rounded-full text-xs transition-all duration-200 ${
           currentLocale === "en"
             ? "bg-[var(--color-bg-elevated)] text-[var(--color-ink)] shadow-sm"
@@ -33,7 +40,7 @@ export default function LanguageToggle({ currentLocale }: LanguageToggleProps) {
       </Link>
       <Link
         href={getPath("he")}
-        onClick={() => localStorage.setItem("locale", "he")}
+        onClick={() => rememberLocale("he")}
         className={`px-3.5 py-1.5 sm:px-3 sm:py-1 rounded-full text-xs transition-all duration-200 ${
           currentLocale === "he"
             ? "bg-[var(--color-bg-elevated)] text-[var(--color-ink)] shadow-sm"


### PR DESCRIPTION
## Summary
- Bare-domain (\`/\`) requests were served by a page that called \`window.location.replace()\` on mount. This destroyed the JS execution context mid-probe for automated checkers — isitagentready's WebMCP check reported *"Execution context was destroyed"* because \`Runtime.evaluate\` raced the navigation and lost.
- Move the redirect into the existing CloudFront viewer-request function: \`/\` now returns a \`302\` to \`/<locale>\`, choosing locale from **cookie → Accept-Language → \`en\`**
- Reduce the landing page to a \`<noscript>\` meta-refresh fallback (only fires if the edge function doesn't, and \`<noscript>\` means it's inert for JS-enabled clients including bots)
- \`LanguageToggle\` now also sets a \`locale\` cookie so bookmarked bare-domain visits keep honoring the user's choice

## Test plan
- [ ] \`curl -sI https://recipes.atlow.co.il/\` returns \`302 Found\` with \`location: /en\` (no locale cookie set)
- [ ] \`curl -sI -H "Accept-Language: he" https://recipes.atlow.co.il/\` returns \`location: /he\`
- [ ] \`curl -sI -H "Cookie: locale=he" https://recipes.atlow.co.il/\` returns \`location: /he\` (cookie wins over Accept-Language)
- [ ] Re-run isitagentready on the bare domain — WebMCP check should no longer error with \"Execution context was destroyed\"
- [ ] Click EN/עב toggle in app → subsequent bare-domain visits redirect to the chosen locale
- [ ] \`curl -H "Accept: text/markdown" https://recipes.atlow.co.il/\` still serves \`index.md\` (markdown negotiation preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)