### PR TITLE
feat(agents): publish A2A agent card, switch WebMCP to registerTool API

### DIFF
--- a/website/components/WebMCPProvider.tsx
+++ b/website/components/WebMCPProvider.tsx
@@ -9,125 +9,142 @@ interface WebMCPProviderProps {
   locale: Locale;
 }
 
+type RegisterTool = (tool: ModelContextTool, options?: { signal?: AbortSignal }) => unknown;
+type ProvideContext = (ctx: { tools: ModelContextTool[] }) => unknown;
+
+interface ModelContextTool {
+  name: string;
+  description: string;
+  inputSchema?: object;
+  execute: (input: unknown) => unknown;
+  annotations?: Record<string, unknown>;
+}
+
+interface ModelContextShim {
+  registerTool?: RegisterTool;
+  provideContext?: ProvideContext;
+}
+
 export default function WebMCPProvider({ locale }: WebMCPProviderProps) {
   const router = useRouter();
 
   useEffect(() => {
-    const nav = navigator as Navigator & {
-      modelContext?: {
-        provideContext: (ctx: unknown) => void;
-      };
-    };
+    const nav = navigator as Navigator & { modelContext?: ModelContextShim };
+    const ctx = nav.modelContext;
+    if (!ctx) return;
 
-    if (!nav.modelContext?.provideContext) return;
+    const controller = new AbortController();
+    // Lazy search-index loader: registration is synchronous, the heavy Fuse
+    // index only loads on first tool invocation. This keeps registration
+    // within the checker's probe window even when the JS bundle is large.
+    let indexPromise: ReturnType<typeof loadSearchIndex> | null = null;
+    const getIndex = () => (indexPromise ??= loadSearchIndex());
 
-    const idle = (cb: () => void) => {
-      const w = window as Window & {
-        requestIdleCallback?: (cb: () => void) => number;
-      };
-      if (typeof w.requestIdleCallback === "function") w.requestIdleCallback(cb);
-      else setTimeout(cb, 500);
-    };
-
-    let cancelled = false;
-    idle(async () => {
-      if (cancelled) return;
-      const { fuse, recipes } = await loadSearchIndex();
-      if (cancelled) return;
-
-      nav.modelContext!.provideContext({
-        tools: [
-          {
-            name: "search_recipes",
-            description:
-              "Search Savta's recipe collection by name, ingredient, or tag. Returns matching recipes with slugs and URLs.",
-            inputSchema: {
-              type: "object",
-              properties: {
-                query: {
-                  type: "string",
-                  description: "Search query — recipe name, ingredient, or tag",
-                },
-              },
-              required: ["query"],
-            },
-            execute: (params: { query: string }) => {
-              const results = fuse
-                .search(params.query)
-                .slice(0, 10)
-                .map((r) => ({
-                  slug: r.item.slug,
-                  titleEn: r.item.titleEn,
-                  titleHe: r.item.titleHe,
-                  tags: locale === "he" ? r.item.tagsHe : r.item.tagsEn,
-                  url: `/${locale}/recipe/${r.item.slug}`,
-                }));
-              return { results };
+    const tools: ModelContextTool[] = [
+      {
+        name: "search_recipes",
+        description:
+          "Search Savta's recipe collection by name, ingredient, or tag. Returns matching recipes with slugs and URLs.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "Search query — recipe name, ingredient, or tag",
             },
           },
-          {
-            name: "list_all_recipes",
-            description:
-              "List every recipe in Savta's collection with names, tags, and page URLs.",
-            inputSchema: {
-              type: "object",
-              properties: {},
-            },
-            execute: () => ({
-              recipes: recipes.map((r) => ({
-                slug: r.slug,
-                titleEn: r.titleEn,
-                titleHe: r.titleHe,
-                tags: locale === "he" ? r.tagsHe : r.tagsEn,
-                url: `/${locale}/recipe/${r.slug}`,
+          required: ["query"],
+        },
+        annotations: { readOnlyHint: true },
+        execute: async (input: unknown) => {
+          const { query } = (input as { query: string }) ?? { query: "" };
+          const { fuse } = await getIndex();
+          return {
+            results: fuse
+              .search(query)
+              .slice(0, 10)
+              .map((r) => ({
+                slug: r.item.slug,
+                titleEn: r.item.titleEn,
+                titleHe: r.item.titleHe,
+                tags: locale === "he" ? r.item.tagsHe : r.item.tagsEn,
+                url: `/${locale}/recipe/${r.item.slug}`,
               })),
-            }),
-          },
-          {
-            name: "navigate_to_recipe",
-            description: "Navigate the browser to a specific recipe page.",
-            inputSchema: {
-              type: "object",
-              properties: {
-                slug: {
-                  type: "string",
-                  description: "Recipe slug from search_recipes or list_all_recipes",
-                },
-              },
-              required: ["slug"],
-            },
-            execute: (params: { slug: string }) => {
-              const url = `/${locale}/recipe/${params.slug}`;
-              router.push(url);
-              return { navigating: true, url };
-            },
-          },
-          {
-            name: "navigate_to_search",
-            description:
-              "Navigate to the recipe search page, optionally pre-filled with a query.",
-            inputSchema: {
-              type: "object",
-              properties: {
-                query: {
-                  type: "string",
-                  description: "Optional search query to pre-fill",
-                },
-              },
-            },
-            execute: (params: { query?: string }) => {
-              const url = `/${locale}/search${params.query ? `?q=${encodeURIComponent(params.query)}` : ""}`;
-              router.push(url);
-              return { navigating: true, url };
+          };
+        },
+      },
+      {
+        name: "list_all_recipes",
+        description:
+          "List every recipe in Savta's collection with names, tags, and page URLs.",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+        execute: async () => {
+          const { recipes } = await getIndex();
+          return {
+            recipes: recipes.map((r) => ({
+              slug: r.slug,
+              titleEn: r.titleEn,
+              titleHe: r.titleHe,
+              tags: locale === "he" ? r.tagsHe : r.tagsEn,
+              url: `/${locale}/recipe/${r.slug}`,
+            })),
+          };
+        },
+      },
+      {
+        name: "navigate_to_recipe",
+        description: "Navigate the browser to a specific recipe page.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            slug: {
+              type: "string",
+              description: "Recipe slug from search_recipes or list_all_recipes",
             },
           },
-        ],
-      });
-    });
+          required: ["slug"],
+        },
+        execute: (input: unknown) => {
+          const { slug } = (input as { slug: string }) ?? { slug: "" };
+          const url = `/${locale}/recipe/${slug}`;
+          router.push(url);
+          return { navigating: true, url };
+        },
+      },
+      {
+        name: "navigate_to_search",
+        description:
+          "Navigate to the recipe search page, optionally pre-filled with a query.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "Optional search query to pre-fill",
+            },
+          },
+        },
+        execute: (input: unknown) => {
+          const { query } = (input as { query?: string }) ?? {};
+          const url = `/${locale}/search${query ? `?q=${encodeURIComponent(query)}` : ""}`;
+          router.push(url);
+          return { navigating: true, url };
+        },
+      },
+    ];
 
-    return () => {
-      cancelled = true;
-    };
+    // Prefer the current spec (registerTool per tool). Fall back to the
+    // older provideContext({tools}) form for shims that still implement it.
+    if (typeof ctx.registerTool === "function") {
+      for (const tool of tools) {
+        ctx.registerTool(tool, { signal: controller.signal });
+      }
+    } else if (typeof ctx.provideContext === "function") {
+      ctx.provideContext({ tools });
+    }
+
+    return () => controller.abort();
   }, [locale, router]);
 
   return null;

--- a/website/public/.well-known/agent-card.json
+++ b/website/public/.well-known/agent-card.json
@@ -1,0 +1,66 @@
+{
+  "name": "Savta's Recipes",
+  "description": "Bilingual (English/Hebrew) collection of grandmother's handwritten recipes, digitised, translated, and searchable. Exposes search and listing tools to agents over MCP and via WebMCP in the browser.",
+  "version": "1.0.0",
+  "url": "https://recipes.atlow.co.il",
+  "documentationUrl": "https://recipes.atlow.co.il/en/about",
+  "iconUrl": "https://recipes.atlow.co.il/icon.svg",
+  "provider": {
+    "organization": "atlow.co.il",
+    "url": "https://recipes.atlow.co.il"
+  },
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "extendedAgentCard": false
+  },
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["application/json", "text/markdown"],
+  "supportedInterfaces": [
+    {
+      "url": "https://recipes.atlow.co.il/mcp",
+      "protocolBinding": "streamable-http",
+      "protocolVersion": "2025-06-18",
+      "transport": "https"
+    }
+  ],
+  "skills": [
+    {
+      "id": "search-recipes",
+      "name": "Search Recipes",
+      "description": "Search Savta's recipe collection by name, ingredient, or tag. Returns matching recipes with slugs and URLs in the requested locale.",
+      "tags": ["search", "recipes", "food", "bilingual"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"],
+      "examples": [
+        "Find recipes with chocolate",
+        "What Hanukkah desserts does Savta have?",
+        "חיפוש עוגיות שוקולד"
+      ]
+    },
+    {
+      "id": "list-recipes",
+      "name": "List All Recipes",
+      "description": "List every recipe in the collection with names, tags, and canonical page URLs in the requested locale.",
+      "tags": ["listing", "recipes", "catalog"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "navigate-to-recipe",
+      "name": "Open a Recipe",
+      "description": "Navigate the active browser tab to a recipe's page by slug. Intended for WebMCP contexts where the agent drives a real browser.",
+      "tags": ["navigation", "recipes"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "navigate-to-search",
+      "name": "Open Search",
+      "description": "Navigate the active browser tab to the recipe search page, optionally pre-filled with a query.",
+      "tags": ["navigation", "search"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    }
+  ]
+}

--- a/website/public/.well-known/agent-skills/webmcp/SKILL.md
+++ b/website/public/.well-known/agent-skills/webmcp/SKILL.md
@@ -2,7 +2,7 @@
 name: webmcp
 type: webmcp
 version: 1.0.0
-description: Browser-native AI agent tools via navigator.modelContext.provideContext()
+description: Browser-native AI agent tools via navigator.modelContext.registerTool()
 ---
 
 # webmcp
@@ -11,7 +11,7 @@ Savta's Recipes exposes browser-native tools to AI agents via the [WebMCP](https
 
 ## Implementation
 
-Tools are registered on every recipe page using `navigator.modelContext.provideContext()`.
+Tools are registered on every recipe page using `navigator.modelContext.registerTool()` (one call per tool, matching the current WebMCP spec). The older `provideContext({tools})` form is retained as a runtime fallback for shims that don't implement `registerTool`.
 
 ## Available tools
 


### PR DESCRIPTION
## Summary

Two AI-readiness checker findings addressed in one PR because they're both agent-discovery plumbing:

### 1. A2A Agent Card

Publish \`/.well-known/agent-card.json\` with the required fields (\`name\`, \`version\`, \`description\`, \`supportedInterfaces\`, \`capabilities\`, \`skills\`, \`defaultInputModes\`, \`defaultOutputModes\`). The card points to the existing MCP endpoint at \`https://recipes.atlow.co.il/mcp\` (streamable-http) and lists four skills (search, list, navigate-to-recipe, navigate-to-search).

Previously the checker got HTML from the 404 page because the file didn't exist.

### 2. WebMCP API switch

The current [WebMCP spec](https://webmachinelearning.github.io/webmcp/) registers tools via \`navigator.modelContext.registerTool(tool, {signal})\` called once per tool — not the older \`provideContext({tools: [...]})\` batch form, which our code was using. Checker probes looked for the newer API and reported \"navigator.modelContext not detected.\"

Changes in \`WebMCPProvider\`:
- Call \`registerTool\` per tool (preferred); fall back to \`provideContext\` only for shims that don't expose \`registerTool\`
- Drop the \`requestIdleCallback\` wrapper so registration happens as soon as React hydrates — within the checker's probe window even on slower connections
- Load the Fuse search index lazily inside the \`execute\` callbacks so registration is synchronous (was previously gated on the 156-recipe index parse)
- Use \`AbortSignal\` for cleanup so tools are unregistered on unmount per the spec
- Add \`annotations.readOnlyHint: true\` on the read-only tools

## Test plan
- [ ] Deploy lands
- [ ] \`curl -s https://recipes.atlow.co.il/.well-known/agent-card.json | jq .name\` returns \"Savta's Recipes\"
- [ ] Response is \`Content-Type: application/json\` (not text/html)
- [ ] In a Chromium build with WebMCP enabled (or an isitagentready probe), visit \`/en\` and confirm \`navigator.modelContext.registerTool\` is called 4 times
- [ ] Re-run isitagentready — both A2A and WebMCP checks should now pass
- [ ] Manual smoke: no console errors on \`/en\` or \`/he\`, search still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)