### PR TITLE
fix(web): register WebMCP tools inline so detection can't miss them

### DIFF
--- a/website/app/[locale]/layout.tsx
+++ b/website/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import Navbar from "@/components/Navbar";
 import WebMCPProvider from "@/components/WebMCPProvider";
+import { webMcpInlineScript } from "@/components/webmcp-inline";
 import { type Locale } from "@/lib/recipes";
 
 export function generateStaticParams() {
@@ -19,6 +20,12 @@ export default async function LocaleLayout({
 
   return (
     <div dir={isHebrew ? "rtl" : "ltr"} lang={locale}>
+      {/* Register WebMCP tools synchronously at HTML parse time so
+          detection bots that probe immediately after load can see them,
+          without waiting for React hydration. */}
+      <script
+        dangerouslySetInnerHTML={{ __html: webMcpInlineScript(locale) }}
+      />
       <Navbar locale={locale} />
       <WebMCPProvider locale={locale} />
       <main className="max-w-6xl mx-auto px-4 sm:px-6 py-8">

--- a/website/components/WebMCPProvider.tsx
+++ b/website/components/WebMCPProvider.tsx
@@ -9,142 +9,78 @@ interface WebMCPProviderProps {
   locale: Locale;
 }
 
-type RegisterTool = (tool: ModelContextTool, options?: { signal?: AbortSignal }) => unknown;
-type ProvideContext = (ctx: { tools: ModelContextTool[] }) => unknown;
+type ToolImpl = (input: unknown) => unknown;
 
-interface ModelContextTool {
-  name: string;
-  description: string;
-  inputSchema?: object;
-  execute: (input: unknown) => unknown;
-  annotations?: Record<string, unknown>;
+declare global {
+  interface Window {
+    __webmcpImpl?: Record<string, ToolImpl>;
+  }
 }
 
-interface ModelContextShim {
-  registerTool?: RegisterTool;
-  provideContext?: ProvideContext;
-}
-
+// Tool registration happens synchronously in the inline script emitted by
+// the locale layout (see components/webmcp-inline.ts). This component
+// supplies the real implementations that the inline stubs delegate to via
+// window.__webmcpImpl. Splitting registration from implementation lets
+// detection bots observe registerTool() before React hydration while
+// still letting real invocations use the router and the Fuse index.
 export default function WebMCPProvider({ locale }: WebMCPProviderProps) {
   const router = useRouter();
 
   useEffect(() => {
-    const nav = navigator as Navigator & { modelContext?: ModelContextShim };
-    const ctx = nav.modelContext;
-    if (!ctx) return;
-
-    const controller = new AbortController();
-    // Lazy search-index loader: registration is synchronous, the heavy Fuse
-    // index only loads on first tool invocation. This keeps registration
-    // within the checker's probe window even when the JS bundle is large.
     let indexPromise: ReturnType<typeof loadSearchIndex> | null = null;
     const getIndex = () => (indexPromise ??= loadSearchIndex());
 
-    const tools: ModelContextTool[] = [
-      {
-        name: "search_recipes",
-        description:
-          "Search Savta's recipe collection by name, ingredient, or tag. Returns matching recipes with slugs and URLs.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            query: {
-              type: "string",
-              description: "Search query — recipe name, ingredient, or tag",
-            },
-          },
-          required: ["query"],
-        },
-        annotations: { readOnlyHint: true },
-        execute: async (input: unknown) => {
-          const { query } = (input as { query: string }) ?? { query: "" };
-          const { fuse } = await getIndex();
-          return {
-            results: fuse
-              .search(query)
-              .slice(0, 10)
-              .map((r) => ({
-                slug: r.item.slug,
-                titleEn: r.item.titleEn,
-                titleHe: r.item.titleHe,
-                tags: locale === "he" ? r.item.tagsHe : r.item.tagsEn,
-                url: `/${locale}/recipe/${r.item.slug}`,
-              })),
-          };
-        },
-      },
-      {
-        name: "list_all_recipes",
-        description:
-          "List every recipe in Savta's collection with names, tags, and page URLs.",
-        inputSchema: { type: "object", properties: {} },
-        annotations: { readOnlyHint: true },
-        execute: async () => {
-          const { recipes } = await getIndex();
-          return {
-            recipes: recipes.map((r) => ({
-              slug: r.slug,
-              titleEn: r.titleEn,
-              titleHe: r.titleHe,
-              tags: locale === "he" ? r.tagsHe : r.tagsEn,
-              url: `/${locale}/recipe/${r.slug}`,
+    const impls: Record<string, ToolImpl> = {
+      search_recipes: async (input) => {
+        const { query } = (input as { query: string }) ?? { query: "" };
+        const { fuse } = await getIndex();
+        return {
+          results: fuse
+            .search(query)
+            .slice(0, 10)
+            .map((r) => ({
+              slug: r.item.slug,
+              titleEn: r.item.titleEn,
+              titleHe: r.item.titleHe,
+              tags: locale === "he" ? r.item.tagsHe : r.item.tagsEn,
+              url: `/${locale}/recipe/${r.item.slug}`,
             })),
-          };
-        },
+        };
       },
-      {
-        name: "navigate_to_recipe",
-        description: "Navigate the browser to a specific recipe page.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            slug: {
-              type: "string",
-              description: "Recipe slug from search_recipes or list_all_recipes",
-            },
-          },
-          required: ["slug"],
-        },
-        execute: (input: unknown) => {
-          const { slug } = (input as { slug: string }) ?? { slug: "" };
-          const url = `/${locale}/recipe/${slug}`;
-          router.push(url);
-          return { navigating: true, url };
-        },
+      list_all_recipes: async () => {
+        const { recipes } = await getIndex();
+        return {
+          recipes: recipes.map((r) => ({
+            slug: r.slug,
+            titleEn: r.titleEn,
+            titleHe: r.titleHe,
+            tags: locale === "he" ? r.tagsHe : r.tagsEn,
+            url: `/${locale}/recipe/${r.slug}`,
+          })),
+        };
       },
-      {
-        name: "navigate_to_search",
-        description:
-          "Navigate to the recipe search page, optionally pre-filled with a query.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            query: {
-              type: "string",
-              description: "Optional search query to pre-fill",
-            },
-          },
-        },
-        execute: (input: unknown) => {
-          const { query } = (input as { query?: string }) ?? {};
-          const url = `/${locale}/search${query ? `?q=${encodeURIComponent(query)}` : ""}`;
-          router.push(url);
-          return { navigating: true, url };
-        },
+      navigate_to_recipe: (input) => {
+        const { slug } = (input as { slug: string }) ?? { slug: "" };
+        const url = `/${locale}/recipe/${slug}`;
+        router.push(url);
+        return { navigating: true, url };
       },
-    ];
+      navigate_to_search: (input) => {
+        const { query } = (input as { query?: string }) ?? {};
+        const url = `/${locale}/search${query ? `?q=${encodeURIComponent(query)}` : ""}`;
+        router.push(url);
+        return { navigating: true, url };
+      },
+    };
 
-    // Prefer the current spec (registerTool per tool). Fall back to the
-    // older provideContext({tools}) form for shims that still implement it.
-    if (typeof ctx.registerTool === "function") {
-      for (const tool of tools) {
-        ctx.registerTool(tool, { signal: controller.signal });
+    window.__webmcpImpl = { ...window.__webmcpImpl, ...impls };
+
+    return () => {
+      if (!window.__webmcpImpl) return;
+      for (const name of Object.keys(impls)) {
+        delete window.__webmcpImpl[name];
       }
-    } else if (typeof ctx.provideContext === "function") {
-      ctx.provideContext({ tools });
-    }
-
-    return () => controller.abort();
+    };
   }, [locale, router]);
 
   return null;

--- a/website/components/webmcp-inline.ts
+++ b/website/components/webmcp-inline.ts
@@ -1,0 +1,77 @@
+import type { Locale } from "@/lib/recipes";
+
+// Builds an inline <script> body that synchronously registers the site's
+// WebMCP tools at HTML parse time — before React hydrates. This gives
+// WebMCP clients (and detection bots using CDP-injected shims) a
+// guaranteed chance to observe registerTool calls even if their probe
+// window closes before our React bundle hydrates. Real implementations
+// are supplied later by WebMCPProvider via window.__webmcpImpl.
+export function webMcpInlineScript(locale: Locale): string {
+  const tools = [
+    {
+      name: "search_recipes",
+      description:
+        "Search Savta's recipe collection by name, ingredient, or tag. Returns matching recipes with slugs and URLs.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Search query — recipe name, ingredient, or tag",
+          },
+        },
+        required: ["query"],
+      },
+      annotations: { readOnlyHint: true },
+    },
+    {
+      name: "list_all_recipes",
+      description:
+        "List every recipe in Savta's collection with names, tags, and page URLs.",
+      inputSchema: { type: "object", properties: {} },
+      annotations: { readOnlyHint: true },
+    },
+    {
+      name: "navigate_to_recipe",
+      description: "Navigate the browser to a specific recipe page.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          slug: {
+            type: "string",
+            description: "Recipe slug from search_recipes or list_all_recipes",
+          },
+        },
+        required: ["slug"],
+      },
+    },
+    {
+      name: "navigate_to_search",
+      description:
+        "Navigate to the recipe search page, optionally pre-filled with a query.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Optional search query to pre-fill",
+          },
+        },
+      },
+    },
+  ];
+
+  // Tool metadata is safe-JSON. We attach an execute stub that waits up
+  // to 10s for WebMCPProvider to populate window.__webmcpImpl[name].
+  return `(function(){
+var mc=navigator.modelContext;
+if(!mc)return;
+window.__webmcpLocale=${JSON.stringify(locale)};
+window.__webmcpImpl=window.__webmcpImpl||{};
+var tools=${JSON.stringify(tools)};
+function stub(name){return function(input){return new Promise(function(resolve){var start=Date.now();(function poll(){var fn=window.__webmcpImpl[name];if(fn){try{Promise.resolve(fn(input)).then(resolve,function(e){resolve({error:String(e)})})}catch(e){resolve({error:String(e)})}return}if(Date.now()-start>10000){resolve({error:"tool "+name+" not ready"});return}setTimeout(poll,50)})()})}}
+for(var i=0;i<tools.length;i++){tools[i].execute=stub(tools[i].name)}
+if(typeof mc.registerTool==="function"){for(var j=0;j<tools.length;j++){try{mc.registerTool(tools[j])}catch(e){}}}
+else if(typeof mc.provideContext==="function"){try{mc.provideContext({tools:tools})}catch(e){}}
+})();`;
+}


### PR DESCRIPTION
## Summary

The previous WebMCP implementation registered tools inside a client-component \`useEffect\`. That only fires after the main JS bundle downloads, parses, and React hydrates — hundreds of ms to ~2s after navigation completes. Detection bots (isitagentready) that probe \`navigator.modelContext\` immediately after load were finding zero tools:

\`\`\`
"action": "parse",
"label": "Check imperative WebMCP API",
"finding": { "summary": "No tools registered via navigator.modelContext" }
\`\`\`

Move tool registration into a synchronous inline \`<script>\` emitted by the locale layout. It runs at HTML parse time, before any bundled JS executes — the same execution point a CDP-injected shim would observe.

- Tool metadata (\`name\`, \`description\`, \`inputSchema\`, \`annotations\`) is static and emitted inline
- Execute callbacks are stubs that delegate to \`window.__webmcpImpl[name]\`
- \`WebMCPProvider\` (still a client component) now only *populates* \`window.__webmcpImpl\` from its \`useEffect\` with the real router-backed and Fuse-backed implementations
- If a client invokes a tool before React has hydrated, the stub polls for up to 10s before giving up

Net effect: registration is guaranteed synchronous and pre-hydration, real execution still has the full React context when it happens.

## Test plan
- [ ] After deploy: \`curl -s https://recipes.atlow.co.il/en | grep -c 'navigator.modelContext'\` returns ≥ 1
- [ ] Playwright probe with a pre-load shim on /en records 4 \`registerTool\` calls
- [ ] \`POST https://isitagentready.com/api/scan {"url": "https://recipes.atlow.co.il/en"}\` returns \`checks.discovery.webMcp.status: "pass"\`
- [ ] Manual: search still works, recipe pages still navigate, no console errors

## Note on Content Signals
The same API scan shows the Content Signals check getting a **stale cached robots.txt** from isitagentready's side (73 bytes, pre-signals version — predates \`a4f4148\`). Our live \`robots.txt\` is correct (162 bytes, signals present, \`max-age=300\`). Only the checker operator can purge this — there's nothing we can ship to force their cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)