### PR TITLE
fix: TypeError notes.map is not a function on recipe page

### DIFF
--- a/data/recipes/19231f1d-587a-469b-aae6-07daf9817d4e.json
+++ b/data/recipes/19231f1d-587a-469b-aae6-07daf9817d4e.json
@@ -144,5 +144,10 @@
   "ocrRawText": "German Chocolate Bred\n1½ #\n1) 1C milk\n2) 1 egg\n3) 2T marg. or butter\n4) 2C flour\n5) 1C wheat flour\n6) 3T brown sugar\n7) 2T cocoa powder\n8) 3/4 tsp salt\n9) 1½ tsp. yeast\n10) ½C choc. chips\n11) 1/3C chopped nuts\n12) 1/3C toasted coconut",
   "selectedModel": "claude",
   "rankingReason": "Claude selected (only valid result). Gemini result failed validation: instructions.en: Array must contain at least 1 element(s); instructions.he: Array must contain at least 1 element(s)",
-  "notes": "This recipe card is not in Savta's handwriting — it may have been written by someone else or sourced from another person."
+  "notes": [
+    {
+      "en": "This recipe card is not in Savta's handwriting — it may have been written by someone else or sourced from another person.",
+      "he": "כרטיס המתכון הזה אינו בכתב ידה של סבתא — ייתכן שנכתב על ידי מישהו אחר או נלקח ממקור אחר."
+    }
+  ]
 }

--- a/pipeline/src/schema.ts
+++ b/pipeline/src/schema.ts
@@ -32,7 +32,7 @@ export const recipeSchema = z.object({
   ocrRawText: z.string(),
   selectedModel: z.enum(["gemini", "claude"]),
   rankingReason: z.string(),
-  notes: z.string().optional(),
+  notes: z.array(bilingualText).optional(),
 });
 
 export type Recipe = z.infer<typeof recipeSchema>;


### PR DESCRIPTION
## Summary

- The pipeline Zod schema defined `notes` as `z.string().optional()`, but the website type and page component both expect `Array<{ en: string; he: string }>`.
- One recipe (`19231f1d-587a-469b-aae6-07daf9817d4e.json` — German Chocolate Bread) had its `notes` stored as a plain string, causing `TypeError: j.notes.map is not a function` at runtime.

## Changes

- `pipeline/src/schema.ts`: changed `notes` type from `z.string().optional()` to `z.array(bilingualText).optional()` so future pipeline runs produce the correct format
- `data/recipes/19231f1d-587a-469b-aae6-07daf9817d4e.json`: migrated the existing plain-string note to a bilingual `[{ en, he }]` array

## Test plan

- [ ] `npm run build` in `website/` succeeds without TypeError
- [ ] German Chocolate Bread recipe page renders its note correctly in both English and Hebrew

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)