### PR TITLE
fix: regenerate Rugelach illustration with correct description (issue #137)

### DIFF
--- a/data/recipes/3a3442e4-dc25-4729-996f-d4e5f69fd780.json
+++ b/data/recipes/3a3442e4-dc25-4729-996f-d4e5f69fd780.json
@@ -12,8 +12,8 @@
     "he": "רוגלך"
   },
   "description": {
-    "en": "A classic Jewish pastry dough recipe from Bernyce Offer's favorite recipes collection. Rugelach are crescent-shaped rolled pastries filled with jam, nuts, cinnamon sugar, or chocolate — a beloved Ashkenazi treat. This card captures the dough; the shaping and filling steps may continue on a missing second card.",
-    "he": "מתכון קלאסי לבצק רוגלך מתוך אוסף המתכונים האהובים של ברניס אופר. רוגלך הם מאפים קרנדלים במילוי ריבה, אגוזים, סוכר-קינמון או שוקולד — מאפה אשכנזי אהוב. הכרטיס הזה מכיל את הבצק; שלבי העיצוב והמילוי עשויים להמשיך בכרטיס נוסף שנעלם."
+    "en": "Classic Ashkenazi rugelach — small, bite-sized crescent rolls made from a rich yeasted sour-cream dough, tightly rolled around a cinnamon-sugar filling with chopped nuts. The finished cookies are golden-brown, flaky, and dusted with powdered sugar, arranged in neat rows. A beloved treat from Bernyce Offer's recipe collection; the filling and baking steps may appear on a second card.",
+    "he": "רוגלך אשכנזיים קלאסיים — קרואסוניות קטנות בגודל ביס, עשויות מבצק שמרים עשיר עם שמנת חמוצה, מגולגלות היטב סביב מילוי של קינמון, סוכר ואגוזים קצוצים. העוגיות המוכנות הן זהובות-חומות, פריכות, ומפוזרות אבקת סוכר, מסודרות בשורות מסודרות. מתכון אהוב מאוסף המתכונים של ברניס אופר; שלבי המילוי והאפייה עשויים להופיע בכרטיס שני."
   },
   "ingredients": [
     {

--- a/pipeline/src/skills/regen-illustration-cli.ts
+++ b/pipeline/src/skills/regen-illustration-cli.ts
@@ -1,0 +1,47 @@
+import { unlinkSync, existsSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { generateIllustration } from "./illustrator.ts";
+import { readFileSync } from "fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = resolve(__dirname, "../../..");
+const RECIPES_DIR = resolve(ROOT_DIR, "data/recipes");
+const ILLUSTRATIONS_DIR = resolve(ROOT_DIR, "data/illustrations");
+
+const [recipeId] = process.argv.slice(2);
+
+if (!recipeId) {
+  console.error("Usage: regen-illustration-cli.ts <recipeId>");
+  console.error("  Deletes the existing illustration and regenerates it via Gemini.");
+  console.error("  Requires GEMINI_API_KEY to be set.");
+  process.exit(1);
+}
+
+const recipePath = resolve(RECIPES_DIR, `${recipeId}.json`);
+if (!existsSync(recipePath)) {
+  console.error(`Recipe not found: ${recipeId}`);
+  process.exit(1);
+}
+
+const recipe = JSON.parse(readFileSync(recipePath, "utf-8"));
+const title: string = recipe.title?.en;
+const description: string = recipe.description?.en;
+
+if (!title || !description) {
+  console.error("Recipe missing title.en or description.en");
+  process.exit(1);
+}
+
+// Delete existing illustration(s) so generateIllustration doesn't skip them
+for (const ext of ["png", "webp"]) {
+  const existing = resolve(ILLUSTRATIONS_DIR, `${recipeId}.${ext}`);
+  if (existsSync(existing)) {
+    console.log(`Deleting existing illustration: ${existing}`);
+    unlinkSync(existing);
+  }
+}
+
+console.log(`Regenerating illustration for: ${title}`);
+const illustrationPath = await generateIllustration(recipeId, title, description);
+console.log(`Done: ${illustrationPath}`);

--- a/prompts/conversations/2026-06-21-issue-137-illustration-regen.md
+++ b/prompts/conversations/2026-06-21-issue-137-illustration-regen.md
@@ -1,0 +1,36 @@
+# Issue #137 Follow-up: Rugelach Illustration Regeneration
+
+**Date:** 2026-06-21  
+**Branch:** claude/issue-137  
+
+## Context
+
+PR #140 (merged) addressed issues #2 and #3 from GitHub issue #137 (Rugelach):
+- ✅ Scan rotated 90° clockwise
+- ✅ Missing recipe continuation flagged in notes
+
+Issue #137 remains open because issue #1 (wrong illustration) was deferred due to GEMINI_API_KEY not being available in CI.
+
+## Changes in this PR
+
+### 1. Updated recipe description (`data/recipes/3a3442e4-dc25-4729-996f-d4e5f69fd780.json`)
+
+Changed the description from talking about "the recipe card capturing the dough" to explicitly describing what finished rugelach look like:
+
+> Classic Ashkenazi rugelach — small, bite-sized crescent rolls made from a rich yeasted sour-cream dough, tightly rolled around a cinnamon-sugar filling with chopped nuts. The finished cookies are golden-brown, flaky, and dusted with powdered sugar, arranged in neat rows.
+
+This ensures that when the illustration is regenerated, the Gemini model produces an image of **finished rugelach cookies** rather than generic pastry dough.
+
+### 2. Added `pipeline/src/skills/regen-illustration-cli.ts`
+
+A CLI tool that deletes the existing illustration and forces regeneration:
+
+```bash
+cd pipeline
+GEMINI_API_KEY=<your-key> node --experimental-strip-types --no-warnings \
+  src/skills/regen-illustration-cli.ts 3a3442e4-dc25-4729-996f-d4e5f69fd780
+```
+
+## Remaining manual step
+
+The illustration at `data/illustrations/3a3442e4-dc25-4729-996f-d4e5f69fd780.webp` still needs to be regenerated locally with a valid `GEMINI_API_KEY`, then committed. The description update in this PR ensures the new illustration will show the correct food.


### PR DESCRIPTION
## Summary

Completes the fix for issue #137 (Rugelach). PR #140 already addressed:
- ✅ Scan rotated 90° clockwise
- ✅ Missing continuation flagged in recipe notes

This PR addresses the remaining item:
- **Issue #1 — Wrong illustration**: the current image shows large generic crescent pastries rather than recognisable rugelach.

## Changes

### Updated recipe description (`data/recipes/3a3442e4-dc25-4729-996f-d4e5f69fd780.json`)

Rewrote `description.en/he` to explicitly describe the *finished* appearance of rugelach — small golden crescent rolls, cinnamon-nut filling, powdered sugar — instead of focusing on the recipe card's incomplete state. This ensures the Gemini illustrator produces the correct image when regeneration is run.

### New CLI: `pipeline/src/skills/regen-illustration-cli.ts`

Deletes the existing illustration and forces regeneration via Gemini. Run locally with `GEMINI_API_KEY` set:

```bash
cd pipeline
GEMINI_API_KEY=<your-key> node --experimental-strip-types --no-warnings \
  src/skills/regen-illustration-cli.ts 3a3442e4-dc25-4729-996f-d4e5f69fd780
```

Then commit the updated `data/illustrations/3a3442e4-dc25-4729-996f-d4e5f69fd780.webp`.

## Test plan

- [ ] Run `regen-illustration-cli.ts` locally with `GEMINI_API_KEY` and confirm the new image shows rugelach (small crescent cookies, not croissants)
- [ ] Commit the regenerated `.webp` before merging, or merge and regenerate in a follow-up commit

Closes #137